### PR TITLE
[publisher] Initial commit of publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is a BETA - there may still be some bugs, and behavior may change in the fu
 - Generic JSON integration for S3 Logs
 - AWS ELB integration for S3 Logs
 - S3 Bucket Log integration for S3 Logs
+- Honeycomb Publisher for Lambda
 
 ## Installation
 
@@ -63,6 +64,13 @@ Enable events __Put__ and __Complete Multipart Upload__ and select the lambda be
 ### Generic JSON integration for SNS
 
 [Click here](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=honeycomb-sns-integration&templateURL=https://s3.amazonaws.com/honeycomb-builds/honeycombio/integrations-for-aws/LATEST/templates/sns-json.yml) to launch the AWS Cloudformation Console to create the integration stack. You will need one stack per SNS topic that you want to subscribe to.
+
+### Honeycomb Publisher for Lambda
+
+The Honeycomb Publisher for Lambda receives and publishes Honeycomb events on behalf of other Honeycomb-instrumented Lambda functions. It allows events to be sent asynchronously, rather than blocking the upstream function.
+
+[Click here](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=honeycomb-publisher&templateURL=https://s3.amazonaws.com/honeycomb-builds/honeycombio/integrations-for-aws/LATEST/templates/publisher.yml) to install.
+
 
 ### Other integrations
 

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ ROOT_DIR=$(pwd)
 rm -rf pkg
 mkdir pkg
 
-HANDLERS="cloudwatch-handler s3-handler sns-handler"
+HANDLERS="cloudwatch-handler s3-handler sns-handler publisher"
 
 for HANDLER in ${HANDLERS}; do
 	cd ${HANDLER}

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/honeycombio/agentless-integrations-for-aws/common"
+	"github.com/sirupsen/logrus"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/honeycombio/honeytail/parsers"
+	"github.com/honeycombio/libhoney-go"
+)
+
+type payload struct {
+	time       time.Time
+	sampleRate uint
+	dataset    string
+	data       interface{}
+}
+
+func extractPayload(data map[string]interface{}) (*payload, error) {
+	p := &payload{}
+	_data, ok := data["data"]
+	if !ok {
+		return nil, fmt.Errorf("unable to find data in payload")
+	}
+	if timestamp, ok := data["time"].(string); ok {
+		if parsedTime, err := time.Parse("2006-01-02T15:04:05.000000Z", timestamp); err == nil {
+			p.time = parsedTime
+		}
+	}
+	if dataset, ok := data["dataset"].(string); ok {
+		p.dataset = dataset
+	}
+	if sampleRate, ok := data["samplerate"].(float64); ok {
+		p.sampleRate = uint(sampleRate)
+	}
+	p.data = _data
+
+	return p, nil
+}
+
+// Response is a simple structured response
+type Response struct {
+	Ok      bool   `json:"ok"`
+	Message string `json:"message"`
+}
+
+var parser parsers.LineParser
+var parserType, timeFieldName, timeFieldFormat, env string
+
+func Handler(request events.CloudwatchLogsEvent) (Response, error) {
+	if parser == nil {
+		return Response{
+			Ok:      false,
+			Message: "parser not initialized, cannot process events",
+		}, fmt.Errorf("parser not initialized, cannot process events")
+	}
+
+	data, err := request.AWSLogs.Parse()
+	if err != nil {
+		return Response{
+			Ok:      false,
+			Message: fmt.Sprintf("failed to parse cloudwatch event data: %s", err.Error()),
+		}, err
+	}
+	for _, event := range data.LogEvents {
+		parsedLine, err := parser.ParseLine(event.Message)
+		if err != nil {
+			logrus.WithError(err).WithField("line", event.Message).
+				Warn("unable to parse line, skipping")
+			continue
+		}
+		// The JSON parser returns a map[string]interface{} - we need to convert it
+		// to a structure we can work with
+		payload, err := extractPayload(parsedLine)
+		if err != nil {
+			logrus.WithError(err).WithField("line", event.Message).
+				Warn("unable to get event payload from line, skipping")
+		}
+		hnyEvent := libhoney.NewEvent()
+		// add the actual event data
+		hnyEvent.Add(payload.data)
+
+		// If we have sane values for other fields, set those as well
+		if !payload.time.IsZero() {
+			hnyEvent.Timestamp = payload.time
+		}
+		if payload.dataset != "" {
+			hnyEvent.Dataset = payload.dataset
+		}
+		if payload.sampleRate > 0 {
+			hnyEvent.SampleRate = payload.sampleRate
+		}
+
+		// We don't sample here - we assume it has been done upstream by
+		// whatever wrote to the log
+		hnyEvent.SendPresampled()
+	}
+
+	libhoney.Flush()
+
+	return Response{
+		Ok:      true,
+		Message: "ok",
+	}, nil
+}
+
+func main() {
+	var err error
+	if err = common.InitHoneycombFromEnvVars(); err != nil {
+		logrus.WithError(err).
+			Fatal("Unable to initialize libhoney with the supplied environment variables")
+		return
+	}
+	defer libhoney.Close()
+
+	parser, err = common.ConstructParser("json")
+	if err != nil {
+		logrus.WithError(err).WithField("parser_type", parserType).
+			Fatal("unable to construct parser")
+		return
+	}
+	common.AddUserAgentMetadata("publisher", "json")
+
+	lambda.Start(Handler)
+}

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestExtractPayload(t *testing.T) {
+	line := `{"samplerate":1,"dataset":"travis.serverless-test","data":{"trace.span_id":"28320411-35c9-45dc-b968-b8b9d091f4bf","meta.local_hostname":"ip-10-12-92-115","trace.trace_id":"6614adb4-a74e-47a2-92de-06435f548eb1","name":"sleepytime","service_name":"travis.serverless-test","trace.parent_id":"56c10d68-e8db-46d5-97ad-0d508a3c08bf","duration_ms":500.65700000000004,"meta.beeline_version":"1.0.0"},"user_agent":"libhoney-py/1.4.0","time":"2018-07-23T22:06:58.471593Z"}`
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(line), &data)
+	if err != nil {
+		t.Error("didn't parse json: ", err)
+	}
+	payload, err := extractPayload(data)
+	if err != nil {
+		t.Error("extractPayload failed: ", err)
+	}
+	if payload.dataset != "travis.serverless-test" {
+		t.Error("unexpected value for dataset: ", payload.dataset)
+	}
+	if payload.sampleRate != 1 {
+		t.Error("unexpected value for sampleRate: ", payload.sampleRate)
+	}
+	expectedTime, err := time.Parse("2006-01-02T15:04:05.000000Z", "2018-07-23T22:06:58.471593Z")
+	if err != nil {
+		t.Error("error parsing time: ", err)
+	}
+	if expectedTime != payload.time {
+		t.Error("unexpected value for time: ", payload.time)
+	}
+}

--- a/templates/publisher.yml
+++ b/templates/publisher.yml
@@ -1,0 +1,222 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: This template builds the necessary lambda infra for the Honeycomb Publisher.
+Parameters:
+  HoneycombWriteKey:
+    Type: String
+    Description: Your Honeycomb write key. If KMSKeyId is set, this should be a Cyphertext Blob from KMS.
+  KMSKeyId:
+    Type: String
+    Default: ''
+    Description: 'KMS Key ID used to encrypt your Honeycomb write key (ex: a80d80aa-19b5-486a-a163-a4502b5555)'
+  HoneycombAPIHost:
+    Type: String
+    Default: https://api.honeycomb.io
+    Description: Optional. Altenative Honeycomb API host.
+  HoneycombDataset:
+    Type: String
+    Default: lambda-events
+    Description: Catch-all dataset used if upstream events did not include a dataset
+  LogGroupName:
+    Type: String
+    Description: The name of the AWS Cloudwatch Log Group to subscribe to
+  LogGroupName1:
+    Type: String
+    Default: ''
+    Description: Additional log group to subscribe to
+  LogGroupName2:
+    Type: String
+    Default: ''
+    Description: Additional log group to subscribe to
+  LogGroupName3:
+    Type: String
+    Default: ''
+    Description: Additional log group to subscribe to
+  LogGroupName4:
+    Type: String
+    Default: ''
+    Description: Additional log group to subscribe to
+  LogGroupName5:
+    Type: String
+    Default: ''
+    Description: Additional log group to subscribe to
+  FilterPattern:
+    Type: String
+    Default: ''
+    Description: The filtering expressions that restrict which cloudwatch log lines get sent
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Required Parameters
+        Parameters:
+          - LogGroupName
+          - HoneycombWriteKey
+          - HoneycombDataset
+      - Label:
+          default: Optional Parameters
+        Parameters:
+          - LogGroupName1
+          - LogGroupName2
+          - LogGroupName3
+          - LogGroupName4
+          - LogGroupName5
+          - KMSKeyId
+          - FilterPattern
+          - HoneycombAPIHost
+Conditions:
+  EncryptionEnabled: !Not [!Equals [!Ref KMSKeyId, '']]
+  LogGroup1Enabled: !Not [!Equals [!Ref LogGroupName1, '']]
+  LogGroup2Enabled: !Not [!Equals [!Ref LogGroupName2, '']]
+  LogGroup3Enabled: !Not [!Equals [!Ref LogGroupName3, '']]
+  LogGroup4Enabled: !Not [!Equals [!Ref LogGroupName4, '']]
+  LogGroup5Enabled: !Not [!Equals [!Ref LogGroupName5, '']]
+Resources:
+  PublisherLambdaHandler:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        S3Bucket: honeycomb-builds
+        S3Key: honeycombio/integrations-for-aws/LATEST/ingest-handlers.zip
+      Description: Lambda function for publishing asynchronous events from Lambda
+      Environment:
+        Variables:
+          HONEYCOMB_WRITE_KEY: !Ref HoneycombWriteKey
+          KMS_KEY_ID: !Ref KMSKeyId
+          API_HOST: !Ref HoneycombAPIHost
+          DATASET: !Ref HoneycombDataset
+      FunctionName:
+        "Fn::Join":
+          - '-'
+          -
+            - PublisherLambdaHandler
+            - !Ref "AWS::StackName"
+      Handler: publisher
+      MemorySize: 128
+      Role:
+        "Fn::GetAtt":
+          - LambdaIAMRole
+          - Arn
+      Runtime: go1.x
+      Timeout: 10
+  ExecutePermission:
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName:
+        "Fn::GetAtt":
+          - PublisherLambdaHandler
+          - Arn
+      Principal: 'logs.amazonaws.com'
+  CloudwatchSubscriptionFilter:
+    Type: "AWS::Logs::SubscriptionFilter"
+    Properties:
+      DestinationArn:
+        "Fn::GetAtt":
+          - PublisherLambdaHandler
+          - Arn
+      LogGroupName: !Ref LogGroupName
+      FilterPattern: !Ref FilterPattern
+    DependsOn: ExecutePermission
+  # hacky work-around to allow multiple optional inputs for log group name
+  # clearly hitting some limitations of the Cloudformation workflow here
+  CloudwatchSubscriptionFilter1:
+    Type: "AWS::Logs::SubscriptionFilter"
+    Condition: LogGroup1Enabled
+    Properties:
+      DestinationArn:
+        "Fn::GetAtt":
+          - PublisherLambdaHandler
+          - Arn
+      LogGroupName: !Ref LogGroupName1
+      FilterPattern: !Ref FilterPattern
+    DependsOn: ExecutePermission
+  CloudwatchSubscriptionFilter2:
+    Type: "AWS::Logs::SubscriptionFilter"
+    Condition: LogGroup2Enabled
+    Properties:
+      DestinationArn:
+        "Fn::GetAtt":
+          - PublisherLambdaHandler
+          - Arn
+      LogGroupName: !Ref LogGroupName2
+      FilterPattern: !Ref FilterPattern
+    DependsOn: ExecutePermission
+  CloudwatchSubscriptionFilter3:
+    Type: "AWS::Logs::SubscriptionFilter"
+    Condition: LogGroup3Enabled
+    Properties:
+      DestinationArn:
+        "Fn::GetAtt":
+          - PublisherLambdaHandler
+          - Arn
+      LogGroupName: !Ref LogGroupName3
+      FilterPattern: !Ref FilterPattern
+    DependsOn: ExecutePermission
+  CloudwatchSubscriptionFilter4:
+    Type: "AWS::Logs::SubscriptionFilter"
+    Condition: LogGroup4Enabled
+    Properties:
+      DestinationArn:
+        "Fn::GetAtt":
+          - PublisherLambdaHandler
+          - Arn
+      LogGroupName: !Ref LogGroupName4
+      FilterPattern: !Ref FilterPattern
+    DependsOn: ExecutePermission
+  CloudwatchSubscriptionFilter5:
+    Type: "AWS::Logs::SubscriptionFilter"
+    Condition: LogGroup5Enabled
+    Properties:
+      DestinationArn:
+        "Fn::GetAtt":
+          - PublisherLambdaHandler
+          - Arn
+      LogGroupName: !Ref LogGroupName5
+      FilterPattern: !Ref FilterPattern
+    DependsOn: ExecutePermission
+  LambdaIAMRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+  LambdaLogPolicy:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: "lambda-create-log"
+      Roles:
+          - Ref: LambdaIAMRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Resource: 'arn:aws:logs:*:*:*'
+  LambdaKMSPolicy:
+    Type: "AWS::IAM::Policy"
+    Condition: EncryptionEnabled
+    Properties:
+      PolicyName: "lambda-kms-decrypt"
+      Roles:
+          - Ref: LambdaIAMRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource:
+              "Fn::Join":
+                - ''
+                -
+                  - arn:aws:kms:*:*:key/
+                  - !Ref KMSKeyId


### PR DESCRIPTION
The Honeycomb Publisher (for lack of a better name) is intended to allow Honeycomb users that have instrumented their app with Honeycomb to publish events asynchronously. Normally, Honeycomb events get sent from Lambda like this:

`Start Lambda -> New Event -> Send Event -> Event Queued -> Flush -> HTTPS call to Honeycomb -> End Lambda`

This adds a non-trivial amount of latency to every Lambda invocation. With updated Transmission implementations in libhoney (example: https://github.com/honeycombio/libhoney-py/pull/38), the flow can look something like this:

`Start Lambda -> New Event -> Send Event -> STDOUT -> End Lambda`

This output to STDOUT is non-blocking. The publisher is meant to offload the work of actually talking to the Honeycomb API, and works something like:

`STDOUT -> Cloudwatch Logs -> Log Filter Subscription -> Publisher -> Honeycomb API`