### PR TITLE
Add handler for RDS MySQL Cloudwatch Logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ pkg
 cloudwatch-handler/cloudwatch-handler
 s3-handler/s3-handler
 sns-handler/sns-handler
+mysql-handler/mysql-handler

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a BETA - there may still be some bugs, and behavior may change in the fu
 - AWS ELB integration for S3 Logs
 - AWS ALB integration for S3 Logs
 - S3 Bucket Log integration for S3 Logs
+- MySQL RDS Integration for Cloudwatch Logs
 
 ## Installation
 
@@ -100,6 +101,14 @@ After this is installed, you will need to manually configure your ALB log bucket
 This is used to parse S3 server access logs, which, if configured, are written to another bucket periodically by the S3 service.
 
 [Click here to install the AWS S3 Bucket Log Integration](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=honeycomb-s3-bucket-log-integration&templateURL=https://s3.amazonaws.com/honeycomb-builds/honeycombio/integrations-for-aws/LATEST/templates/s3-bucket-logs.yml)
+
+#### MySQL RDS Integration for Cloudwatch Logs
+
+You can configure MySQL on RDS to publish its slow query and audit logs to Cloudwatch Logs. For more information, click [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.Concepts.MySQL.html#USER_LogAccess.MySQLDB.PublishtoCloudWatchLogs).
+
+After configuring RDS to write to Cloudwatch Logs, you can install the MySQL RDS Integration below and get rich MySQL event data into Honeycomb in a matter of minutes. Simply supply one or more RDS Cloudwatch Log groups to monitor, provide your Honeycomb write key, and go!
+
+[Click here to install the Mysql RDS Integration](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=honeycomb-rds-mysql-log-integration&templateURL=https://s3.amazonaws.com/honeycomb-builds/honeycombio/integrations-for-aws/LATEST/templates/cloudwatch-rds-mysql.yml)
 
 ## How it works
 

--- a/build.sh
+++ b/build.sh
@@ -5,14 +5,14 @@ set -e
 
 ./test.sh
 
-VERSION=1.1.3
+VERSION=1.2.0
 DEPLOY_ROOT=s3://honeycomb-builds/honeycombio/integrations-for-aws
 
 ROOT_DIR=$(pwd)
 rm -rf pkg
 mkdir pkg
 
-HANDLERS="cloudwatch-handler s3-handler sns-handler"
+HANDLERS="cloudwatch-handler s3-handler sns-handler mysql-handler"
 
 for HANDLER in ${HANDLERS}; do
 	cd ${HANDLER}

--- a/common/common.go
+++ b/common/common.go
@@ -25,7 +25,7 @@ var (
 )
 
 const (
-	version = "1.1.2"
+	version = "1.2.0"
 )
 
 // InitHoneycombFromEnvVars will attempt to call libhoney.Init based on values
@@ -145,4 +145,9 @@ func AddUserAgentMetadata(handler, parser string) {
 	libhoney.UserAgentAddition = fmt.Sprintf(
 		"%s (%s, %s)", libhoney.UserAgentAddition, handler, parser,
 	)
+}
+
+// GetSampleRate returns the sample rate the configured sample rate
+func GetSampleRate() uint {
+	return sampleRate
 }

--- a/mysql-handler/main.go
+++ b/mysql-handler/main.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/honeycombio/agentless-integrations-for-aws/common"
+	"github.com/sirupsen/logrus"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/honeycombio/honeytail/event"
+	"github.com/honeycombio/honeytail/parsers/mysql"
+	"github.com/honeycombio/libhoney-go"
+)
+
+// Response is a simple structured response
+type Response struct {
+	Ok      bool   `json:"ok"`
+	Message string `json:"message"`
+}
+
+var parser *mysql.Parser
+var env, scrubQuery string
+
+func Handler(request events.CloudwatchLogsEvent) (Response, error) {
+	if parser == nil {
+		return Response{
+			Ok:      false,
+			Message: "parser not initialized, cannot process events",
+		}, fmt.Errorf("parser not initialized, cannot process events")
+	}
+
+	data, err := request.AWSLogs.Parse()
+	if err != nil {
+		return Response{
+			Ok:      false,
+			Message: fmt.Sprintf("failed to parse cloudwatch event data: %s", err.Error()),
+		}, err
+	}
+
+	lines := make(chan string)
+	events := make(chan event.Event)
+	wg := sync.WaitGroup{}
+
+	go func() {
+		for _, event := range data.LogEvents {
+			// these are multi log lines, split into individual lines as the
+			// parser expects that
+			messageLines := strings.Split(event.Message, "\n")
+			for _, l := range messageLines {
+				lines <- l
+			}
+		}
+		close(lines)
+	}()
+
+	go func() {
+		wg.Add(1)
+		for e := range events {
+			hnyEvent := libhoney.NewEvent()
+			if scrubQuery == "true" {
+				if val, ok := e.Data["query"]; ok {
+					// generate a sha256 hash
+					newVal := sha256.Sum256([]byte(fmt.Sprintf("%v", val)))
+					// and use the base16 string version of it
+					e.Data["query"] = fmt.Sprintf("%x", newVal)
+				}
+			}
+			hnyEvent.Add(e.Data)
+			hnyEvent.Timestamp = e.Timestamp
+			hnyEvent.SampleRate = uint(e.SampleRate)
+			if env != "" {
+				hnyEvent.AddField("env", env)
+			}
+			// Sampling is done in the parser for greater efficiency
+			hnyEvent.SendPresampled()
+		}
+		wg.Done()
+	}()
+
+	parser.ProcessLines(lines, events, nil)
+	close(events)
+
+	wg.Wait()
+
+	libhoney.Flush()
+
+	return Response{
+		Ok:      true,
+		Message: "ok",
+	}, nil
+}
+
+func main() {
+	var err error
+	if err = common.InitHoneycombFromEnvVars(); err != nil {
+		logrus.WithError(err).
+			Fatal("Unable to initialize libhoney with the supplied environment variables")
+		return
+	}
+	defer libhoney.Close()
+
+	parser = &mysql.Parser{SampleRate: int(common.GetSampleRate())}
+	parser.Init(&mysql.Options{})
+
+	common.AddUserAgentMetadata("rds", "mysql")
+
+	env = os.Getenv("ENVIRONMENT")
+	scrubQuery = os.Getenv("SCRUB_QUERY")
+
+	lambda.Start(Handler)
+}

--- a/templates/cloudwatch-rds-mysql.yml
+++ b/templates/cloudwatch-rds-mysql.yml
@@ -1,0 +1,243 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: This template builds the necessary lambda infra to send cloudwatch logs to honeycomb
+Parameters:
+  Environment:
+    Type: String
+    Default: ''
+    Description: Name of environment. This will be included in log events sent to Honeycomb.
+  HoneycombWriteKey:
+    Type: String
+    Description: Your Honeycomb write key. If KMSKeyId is set, this should be a Cyphertext Blob from KMS.
+  KMSKeyId:
+    Type: String
+    Default: ''
+    Description: 'KMS Key ID used to encrypt your Honeycomb write key (ex: a80d80aa-19b5-486a-a163-a4502b5555)'
+  HoneycombAPIHost:
+    Type: String
+    Default: https://api.honeycomb.io
+    Description: Optional. Altenative Honeycomb API host.
+  HoneycombDataset:
+    Type: String
+    Default: rds-mysql-logs
+    Description: Target honeycomb dataset
+  HoneycombSampleRate:
+    Type: Number
+    Default: 1
+    Description: Sample rate. See https://honeycomb.io/docs/guides/sampling/.
+  LogGroupName:
+    Type: String
+    Description: The name of the AWS Cloudwatch Log Group to subscribe to
+  LogGroupName1:
+    Type: String
+    Default: ''
+    Description: Additional log group to subscribe to
+  LogGroupName2:
+    Type: String
+    Default: ''
+    Description: Additional log group to subscribe to
+  LogGroupName3:
+    Type: String
+    Default: ''
+    Description: Additional log group to subscribe to
+  LogGroupName4:
+    Type: String
+    Default: ''
+    Description: Additional log group to subscribe to
+  LogGroupName5:
+    Type: String
+    Default: ''
+    Description: Additional log group to subscribe to
+  FilterPattern:
+    Type: String
+    Default: ''
+    Description: The filtering expressions that restrict which cloudwatch log lines get sent
+  ScrubQuery:
+    Type: String
+    Default: false
+    Description: Replaces the query field with a one-way hash of the contents
+    AllowedValues:
+      - true
+      - false
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Required Parameters
+        Parameters:
+          - LogGroupName
+          - HoneycombWriteKey
+          - HoneycombDataset
+          - HoneycombSampleRate
+      - Label:
+          default: Optional Parameters
+        Parameters:
+          - LogGroupName1
+          - LogGroupName2
+          - LogGroupName3
+          - LogGroupName4
+          - LogGroupName5
+          - Environment
+          - KMSKeyId
+          - FilterPattern
+          - HoneycombAPIHost
+          - ScrubQuery
+Conditions:
+  EncryptionEnabled: !Not [!Equals [!Ref KMSKeyId, '']]
+  LogGroup1Enabled: !Not [!Equals [!Ref LogGroupName1, '']]
+  LogGroup2Enabled: !Not [!Equals [!Ref LogGroupName2, '']]
+  LogGroup3Enabled: !Not [!Equals [!Ref LogGroupName3, '']]
+  LogGroup4Enabled: !Not [!Equals [!Ref LogGroupName4, '']]
+  LogGroup5Enabled: !Not [!Equals [!Ref LogGroupName5, '']]
+Resources:
+  CloudwatchLambdaHandler:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        S3Bucket: honeycomb-builds
+        S3Key: honeycombio/integrations-for-aws/LATEST/ingest-handlers.zip
+      Description: Lambda function for sending rds cloudwatch logs to Honeycomb
+      Environment:
+        Variables:
+          ENVIRONMENT: !Ref Environment
+          HONEYCOMB_WRITE_KEY: !Ref HoneycombWriteKey
+          KMS_KEY_ID: !Ref KMSKeyId
+          API_HOST: !Ref HoneycombAPIHost
+          DATASET: !Ref HoneycombDataset
+          SAMPLE_RATE: !Ref HoneycombSampleRate
+          SCRUB_QUERY: !Ref ScrubQuery
+      FunctionName:
+        "Fn::Join":
+          - '-'
+          -
+            - CloudwatchLambdaHandler
+            - !Ref "AWS::StackName"
+      Handler: mysql-handler
+      MemorySize: 128
+      Role:
+        "Fn::GetAtt":
+          - LambdaIAMRole
+          - Arn
+      Runtime: go1.x
+      Timeout: 10
+  ExecutePermission:
+    Type: "AWS::Lambda::Permission"
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName:
+        "Fn::GetAtt":
+          - CloudwatchLambdaHandler
+          - Arn
+      Principal: 'logs.amazonaws.com'
+  CloudwatchSubscriptionFilter:
+    Type: "AWS::Logs::SubscriptionFilter"
+    Properties:
+      DestinationArn:
+        "Fn::GetAtt":
+          - CloudwatchLambdaHandler
+          - Arn
+      LogGroupName: !Ref LogGroupName
+      FilterPattern: !Ref FilterPattern
+    DependsOn: ExecutePermission
+  # hacky work-around to allow multiple optional inputs for log group name
+  # clearly hitting some limitations of the Cloudformation workflow here
+  CloudwatchSubscriptionFilter1:
+    Type: "AWS::Logs::SubscriptionFilter"
+    Condition: LogGroup1Enabled
+    Properties:
+      DestinationArn:
+        "Fn::GetAtt":
+          - CloudwatchLambdaHandler
+          - Arn
+      LogGroupName: !Ref LogGroupName1
+      FilterPattern: !Ref FilterPattern
+    DependsOn: ExecutePermission
+  CloudwatchSubscriptionFilter2:
+    Type: "AWS::Logs::SubscriptionFilter"
+    Condition: LogGroup2Enabled
+    Properties:
+      DestinationArn:
+        "Fn::GetAtt":
+          - CloudwatchLambdaHandler
+          - Arn
+      LogGroupName: !Ref LogGroupName2
+      FilterPattern: !Ref FilterPattern
+    DependsOn: ExecutePermission
+  CloudwatchSubscriptionFilter3:
+    Type: "AWS::Logs::SubscriptionFilter"
+    Condition: LogGroup3Enabled
+    Properties:
+      DestinationArn:
+        "Fn::GetAtt":
+          - CloudwatchLambdaHandler
+          - Arn
+      LogGroupName: !Ref LogGroupName3
+      FilterPattern: !Ref FilterPattern
+    DependsOn: ExecutePermission
+  CloudwatchSubscriptionFilter4:
+    Type: "AWS::Logs::SubscriptionFilter"
+    Condition: LogGroup4Enabled
+    Properties:
+      DestinationArn:
+        "Fn::GetAtt":
+          - CloudwatchLambdaHandler
+          - Arn
+      LogGroupName: !Ref LogGroupName4
+      FilterPattern: !Ref FilterPattern
+    DependsOn: ExecutePermission
+  CloudwatchSubscriptionFilter5:
+    Type: "AWS::Logs::SubscriptionFilter"
+    Condition: LogGroup5Enabled
+    Properties:
+      DestinationArn:
+        "Fn::GetAtt":
+          - CloudwatchLambdaHandler
+          - Arn
+      LogGroupName: !Ref LogGroupName5
+      FilterPattern: !Ref FilterPattern
+    DependsOn: ExecutePermission
+  LambdaIAMRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+  LambdaLogPolicy:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: "lambda-create-log"
+      Roles:
+          - Ref: LambdaIAMRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Resource: 'arn:aws:logs:*:*:*'
+  LambdaKMSPolicy:
+    Type: "AWS::IAM::Policy"
+    Condition: EncryptionEnabled
+    Properties:
+      PolicyName: "lambda-kms-decrypt"
+      Roles:
+          - Ref: LambdaIAMRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource:
+              "Fn::Join":
+                - ''
+                -
+                  - arn:aws:kms:*:*:key/
+                  - !Ref KMSKeyId


### PR DESCRIPTION
https://github.com/honeycombio/rdslogs has an issue where it periodically stops getting log lines from the RDS API. Amazon has confirmed this as a known issue, and has no ETA. They also recommend using Cloudwatch Logs for RDS. This seems to be a better way forward, so here I'm adding a mysql handler to our suite of agentless integrations.