### PR TITLE
Support Kinesis Firehose S3 blobs

### DIFF
--- a/s3-handler/main.go
+++ b/s3-handler/main.go
@@ -60,7 +60,7 @@ func Handler(request events.S3Event) (Response, error) {
 		reader := resp.Body
 		// figure out if this file is gzipped
 		if resp.ContentType != nil {
-			if *resp.ContentType == "application/x-gzip" {
+			if *resp.ContentType == "application/x-gzip" || *resp.ContentType == "application/octet-stream" {
 				reader, err = gzip.NewReader(resp.Body)
 				if err != nil {
 					logrus.WithError(err).WithField("key", record.S3.Object.Key).


### PR DESCRIPTION
We gzip events into kinesis firehose via a lambda processor and have our s3 configuration set to `UNCOMPRESSED`...  Soooo if subscribing to s3 events off the firehose bucket, it'll fail to
unzip due to the `Content-Type` being `application/octet-stream`. 

This allows the agent(less) lambda to optimistically treat as a gzip. 