### PR TITLE
[publisher] Add the cloudwatch logstream to event fields

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -e
 
 ./test.sh
 
-VERSION=1.6.0
+VERSION=1.7.0
 REGIONS="us-east-1 us-east-2 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1"
 
 ROOT_DIR=$(pwd)

--- a/common/common.go
+++ b/common/common.go
@@ -26,7 +26,7 @@ var (
 )
 
 const (
-	version = "1.6.0"
+	version = "1.7.0"
 )
 
 // InitHoneycombFromEnvVars will attempt to call libhoney.Init based on values

--- a/publisher/main.go
+++ b/publisher/main.go
@@ -66,6 +66,7 @@ func Handler(request events.CloudwatchLogsEvent) (Response, error) {
 			Message: fmt.Sprintf("failed to parse cloudwatch event data: %s", err.Error()),
 		}, err
 	}
+
 	for _, event := range data.LogEvents {
 		parsedLine, err := parser.ParseLine(event.Message)
 		if err != nil {
@@ -83,6 +84,9 @@ func Handler(request events.CloudwatchLogsEvent) (Response, error) {
 		hnyEvent := libhoney.NewEvent()
 		// add the actual event data
 		hnyEvent.Add(payload.data)
+		// Include the logstream that this data came from to make it easier to find the source
+		// in Cloudwatch
+		hnyEvent.AddField("aws.cloudwatch.logstream", data.LogStream)
 
 		// If we have sane values for other fields, set those as well
 		if !payload.time.IsZero() {


### PR DESCRIPTION
Sometime's it's useful to know the id of the raw log stream that event(s) came from. Include this to events we send to honeycomb.