### PR TITLE
[s3-handler] allow override of scan buffer size

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -e
 
 ./test.sh
 
-VERSION=1.7.0
+VERSION=1.8.0
 REGIONS="us-east-1 us-east-2 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1"
 
 ROOT_DIR=$(pwd)

--- a/templates/s3-logs-json.yml
+++ b/templates/s3-logs-json.yml
@@ -51,6 +51,10 @@ Parameters:
     Type: String
     Default: ''
     Description: If set, write error events such as parsing errors to this dataset. Can be the same as your primary dataset.
+  BufferSize:
+    Type: String
+    Default: '65536'
+    Description: Can be used to override the default scan buffer size of 64KiB. If you get token too long errors, set this to the maximum size of your individual log lines.
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -102,6 +106,7 @@ Resources:
           MATCH_PATTERNS: !Ref MatchPatterns
           FILTER_PATTERNS: !Ref FilterPatterns
           ERROR_DATASET: !Ref ErrorDataset
+          BUFFER_SIZE: !Ref BufferSize
       FunctionName:
         "Fn::Join":
           - '-'


### PR DESCRIPTION
There are some edge cases where users have extremely large lines (> 64KiB) in their file. In this case, the ScanLines buffer fails with "token too large", causing us to exit. I'm not comfortable just raising this limit for everyone, but giving folks a knob to turn here for their own needs should be fine. Adds a new env variable, which can be set in the updated s3-logs-json template.