### PR TITLE
[s3] base compression on Content-Encoding unless forced

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+# Use the latest 2.1 version of CircleCI pipeline processing engine, see https://circleci.com/docs/2.0/configuration-reference/
+version: 2.1
+
+executors:
+  go:
+    parameters:
+      goversion:
+        type: string
+        default: "12"
+    working_directory: /go/src/github.com/honeycombio/agentless-integrations-for-aws
+    docker:
+      - image: circleci/golang:1.<< parameters.goversion >>
+
+jobs:
+  run_tests:
+    executor: go
+    steps:
+      - checkout
+      # TODO also validate templates
+      - run: go get -v -t -d ./...
+      - run: go test -v ./...
+
+# Orchestrate or schedule a set of jobs, see https://circleci.com/docs/2.0/workflows/
+workflows:
+  version: 2
+  run_tests:
+    jobs:
+      - run_tests
+      # TODO build and deploy here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# agentless-integrations-for-aws Changelog
+## 2.0.0 2019-09-04
+
+Major version increase due to a breaking change in the S3 Integration. In the past we've tried to support processing gzip-compressed objects based on its `Content-Type` header or filename extension. This was dubious because these aren't reliable indicators of whether or not content is gzipped. The correct way to store gzipped content is to set the `Content-Encoding` header in S3 with your object. The S3 handler now looks at this header exclusively. If you have gzipped content in your buckets that is not stored with the correct `Content-Encoding`, you can still force processing using gzip by setting the new `ForceGunzip` parameter to `true` in the Cloudformation template, or by setting `FORCE_GUNZIP=true` in the lambda environment. The handler will attempt to decompress the object, then fall back to uncompressed processing if that fails.
+
+## 1.9.0
+
+Features
+
+- New `FilterFields` option in Cloudwatch and S3 logs handler Cloudformation templates (environment variable is `FILTER_FIELDS` in the Lambda environment). When set to a comma-separated list of strings, will drop fields that match any field name present in the list. You can use this to prevent sensitive data from being sent to Honeycomb. For example, if your log files have the fields named "address" and "zip_code" and you want to drop them, pass a `FilterFields` value of `address,zip_code`.
+
+## 1.8.0
+
+Features
+
+- Allows override of the scan buffer size in the S3 handler. If your log files contain very large lines (> 64KiB), you can set `BUFFER_SIZE` in the lambda environment to a larger value. The S3 Logs Cloudformation Template now also accepts a `BufferSize` parameter.
+
+## 1.7.0
+
+Features
+
+- The AWS Publisher now includes a `aws.cloudwatch.logstream` field indicating the Cloudwatch Log Stream name that was the source of incoming events.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Enable events __Put__ and __Complete Multipart Upload__ and select the lambda be
 
 ![alt text](docs/s3_step3.png)
 
+**Note**: The S3 integration respects the `Content-Encoding` header on the object when deciding to decompress. If your files are gzip-compressed but do not have `Content-Encoding: gzip` set, you will need to set the `ForceGunzip` option to true.
+
 ### Generic JSON integration for SNS
 
 [Click here](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=honeycomb-sns-integration&templateURL=https://s3.amazonaws.com/honeycomb-builds/honeycombio/integrations-for-aws/LATEST/templates/sns-json.yml) to launch the AWS Cloudformation Console to create the integration stack. You will need one stack per SNS topic that you want to subscribe to.

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -e
 
 ./test.sh
 
-VERSION=1.9.0
+VERSION=1.10.0
 REGIONS="us-east-1 us-east-2 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1"
 
 ROOT_DIR=$(pwd)

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -e
 
 ./test.sh
 
-VERSION=1.10.0
+VERSION=2.0.0
 REGIONS="us-east-1 us-east-2 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1"
 
 ROOT_DIR=$(pwd)

--- a/common/common.go
+++ b/common/common.go
@@ -28,7 +28,7 @@ var (
 )
 
 const (
-	version = "1.9.0"
+	version = "1.10.0"
 )
 
 // InitHoneycombFromEnvVars will attempt to call libhoney.Init based on values

--- a/common/common.go
+++ b/common/common.go
@@ -28,7 +28,7 @@ var (
 )
 
 const (
-	version = "1.10.0"
+	version = "2.0.0"
 )
 
 // InitHoneycombFromEnvVars will attempt to call libhoney.Init based on values

--- a/s3-handler/s3_handler_test.go
+++ b/s3-handler/s3_handler_test.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -39,6 +41,7 @@ func TestGetReaderForKey(t *testing.T) {
 		DisableSSL:       aws.Bool(true),
 		S3ForcePathStyle: aws.Bool(true),
 		Endpoint:         aws.String(server.URL),
+		Credentials:      credentials.AnonymousCredentials,
 	})
 
 	reader, err := getReaderForKey(svc, "bucket", "key")
@@ -68,6 +71,7 @@ func TestGetReaderForKey(t *testing.T) {
 		DisableSSL:       aws.Bool(true),
 		S3ForcePathStyle: aws.Bool(true),
 		Endpoint:         aws.String(server.URL),
+		Credentials:      credentials.AnonymousCredentials,
 	})
 
 	reader, err = getReaderForKey(svc, "bucket", "key")
@@ -100,6 +104,7 @@ func TestGetReaderForKey(t *testing.T) {
 		DisableSSL:       aws.Bool(true),
 		S3ForcePathStyle: aws.Bool(true),
 		Endpoint:         aws.String(server.URL),
+		Credentials:      credentials.AnonymousCredentials,
 	})
 
 	reader, err = getReaderForKey(svc, "bucket", "gzipped object no header")
@@ -144,6 +149,7 @@ func TestGetReaderForKey(t *testing.T) {
 		DisableSSL:       aws.Bool(true),
 		S3ForcePathStyle: aws.Bool(true),
 		Endpoint:         aws.String(server.URL),
+		Credentials:      credentials.AnonymousCredentials,
 	})
 
 	reader, err = getReaderForKey(svc, "bucket", "key")

--- a/s3-handler/s3_handler_test.go
+++ b/s3-handler/s3_handler_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetReaderForKey(t *testing.T) {
+	// Test basic gunzipping
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b := &bytes.Buffer{}
+		gw := gzip.NewWriter(b)
+		gw.Write([]byte("gzipped payload"))
+		gw.Close()
+
+		w.Header().Set("Content-Length", strconv.Itoa(b.Len()))
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Type", "plain/text")
+		w.WriteHeader(http.StatusOK)
+
+		io.Copy(w, b)
+	}))
+
+	sess := session.Must(session.NewSession())
+
+	svc := s3.New(sess, &aws.Config{
+		Region:           aws.String(endpoints.UsWest2RegionID),
+		DisableSSL:       aws.Bool(true),
+		S3ForcePathStyle: aws.Bool(true),
+		Endpoint:         aws.String(server.URL),
+	})
+
+	reader, err := getReaderForKey(svc, "bucket", "key")
+	assert.NoError(t, err)
+
+	b := bytes.Buffer{}
+	_, err = io.Copy(&b, reader)
+	assert.NoError(t, err)
+	reader.Close()
+
+	assert.Equal(t, "gzipped payload", b.String())
+
+	server.Close()
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b := &bytes.Buffer{}
+		b.Write([]byte("normal payload"))
+
+		w.Header().Set("Content-Length", strconv.Itoa(b.Len()))
+		w.Header().Set("Content-Type", "plain/text")
+		w.WriteHeader(http.StatusOK)
+
+		io.Copy(w, b)
+	}))
+
+	svc = s3.New(sess, &aws.Config{
+		Region:           aws.String(endpoints.UsWest2RegionID),
+		DisableSSL:       aws.Bool(true),
+		S3ForcePathStyle: aws.Bool(true),
+		Endpoint:         aws.String(server.URL),
+	})
+
+	reader, err = getReaderForKey(svc, "bucket", "key")
+	assert.NoError(t, err)
+
+	b = bytes.Buffer{}
+	_, err = io.Copy(&b, reader)
+	assert.NoError(t, err)
+	reader.Close()
+
+	assert.Equal(t, "normal payload", b.String())
+
+	server.Close()
+	// Now test a gzipped payload without a Content-Encoding header - This should fail until we set forceGunzip
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b := &bytes.Buffer{}
+		gw := gzip.NewWriter(b)
+		gw.Write([]byte("gzipped payload"))
+		gw.Close()
+
+		w.Header().Set("Content-Length", strconv.Itoa(b.Len()))
+		w.Header().Set("Content-Type", "plain/text")
+		w.WriteHeader(http.StatusOK)
+
+		io.Copy(w, b)
+	}))
+
+	svc = s3.New(sess, &aws.Config{
+		Region:           aws.String(endpoints.UsWest2RegionID),
+		DisableSSL:       aws.Bool(true),
+		S3ForcePathStyle: aws.Bool(true),
+		Endpoint:         aws.String(server.URL),
+	})
+
+	reader, err = getReaderForKey(svc, "bucket", "gzipped object no header")
+	assert.NoError(t, err)
+
+	b = bytes.Buffer{}
+	_, err = io.Copy(&b, reader)
+	assert.NoError(t, err)
+	reader.Close()
+
+	assert.NotEqual(t, "gzipped payload", b.String())
+
+	// retry by forcing gunzip
+	forceGunzip = true
+
+	reader, err = getReaderForKey(svc, "bucket", "gzipped object no header")
+	assert.NoError(t, err)
+
+	b = bytes.Buffer{}
+	_, err = io.Copy(&b, reader)
+	assert.NoError(t, err)
+	reader.Close()
+
+	assert.Equal(t, "gzipped payload", b.String())
+
+	server.Close()
+
+	// Ensure fallback works when a non-gzipped object is picked up when forceGzipped is enabled
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b := &bytes.Buffer{}
+		b.Write([]byte("normal payload retry"))
+
+		w.Header().Set("Content-Length", strconv.Itoa(b.Len()))
+		w.Header().Set("Content-Type", "plain/text")
+		w.WriteHeader(http.StatusOK)
+
+		io.Copy(w, b)
+	}))
+
+	svc = s3.New(sess, &aws.Config{
+		Region:           aws.String(endpoints.UsWest2RegionID),
+		DisableSSL:       aws.Bool(true),
+		S3ForcePathStyle: aws.Bool(true),
+		Endpoint:         aws.String(server.URL),
+	})
+
+	reader, err = getReaderForKey(svc, "bucket", "key")
+	assert.NoError(t, err)
+
+	b = bytes.Buffer{}
+	_, err = io.Copy(&b, reader)
+	assert.NoError(t, err)
+	reader.Close()
+
+	assert.Equal(t, "normal payload retry", b.String())
+
+	server.Close()
+}

--- a/templates/s3-logs-json.yml
+++ b/templates/s3-logs-json.yml
@@ -59,6 +59,10 @@ Parameters:
     Type: String
     Description: Comma-separated simple strings to specify which field names to remove from events
     Default: ''
+  ForceGunzip:
+    Type: String
+    Description: If set to true, forces each object through gzip decompression, falling back to no decompression if that fails. You should only need this if you are trying to process gzip-compressed objects and have not set Content-Encoding.
+    Default: 'false'
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -73,6 +77,7 @@ Metadata:
           default: Optional Parameters
         Parameters:
           - FilterFields
+          - ForceGunzip
           - MatchPatterns
           - FilterPatterns
           - LambdaMemorySize
@@ -113,6 +118,7 @@ Resources:
           ERROR_DATASET: !Ref ErrorDataset
           BUFFER_SIZE: !Ref BufferSize
           FILTER_FIELDS: !Ref FilterFields
+          FORCE_GUNZIP: !Ref ForceGunzip
       FunctionName:
         "Fn::Join":
           - '-'


### PR DESCRIPTION
In the past we've tried to support processing gzip-compressed objects based on content-type or filename extension. This was bound to run into problems, and it has: we currently treat `application/octet-stream` as gzip-compressed, but that's wrong. We should be looking at the `Content-Encoding` metadata on the s3 object to determine if it's gzip compressed. The AWS SDK (via the default HTTP transport) does this by default, actually, so we don't even need to do it ourselves if the objects are set with the correct encoding.

Unfortunately, plenty of systems don't set the encoding correctly, which leaves us attempting to make guesses about the compression type. Repeatedly guessing compression type requires multiple S3 reads and is not really efficient, so I'd rather follow the correct behavior (respecting Content-Encoding) and allow an override if we want to try and decompress objects that don't set the encoding header. This will break users relying on the previous `*.gz` or `application/octet-stream` logic, and we'll need to direct them to use the new `ForceGunzip` option.