### PR TITLE
fix alb logs regex

### DIFF
--- a/templates/aws-alb-logs.yml
+++ b/templates/aws-alb-logs.yml
@@ -82,7 +82,7 @@ Resources:
         Variables:
           ENVIRONMENT: !Ref Environment
           PARSER_TYPE: regex
-          REGEX_PATTERN: '(?P<type>.+) (?P<timestamp>.+) (?P<elb>.+) (?P<client>.+) (?P<target>.+) (?P<request_processing_time>.+) (?P<target_processing_time>.+) (?P<response_processing_time>.+) (?P<elb_status_code>.+) (?P<target_status_code>.+) (?P<received_bytes>.+) (?P<sent_bytes>.+) "(?P<request>.+)" "(?P<user_agent>.+)" (?P<ssl_cipher>.+) (?P<ssl_protocol>.+) (?P<target_group_arn>.+) "Root=(?P<trace_id>.+)" "(?P<domain_name>.+)" "(?P<chosen_cert_arn>.+)" (?P<unknown>.+)'
+          REGEX_PATTERN: '(?P<type>.+) (?P<timestamp>.+) (?P<elb>.+) (?P<client>.+) (?P<target>.+) (?P<request_processing_time>.+) (?P<target_processing_time>.+) (?P<response_processing_time>.+) (?P<elb_status_code>.+) (?P<target_status_code>.+) (?P<received_bytes>.+) (?P<sent_bytes>.+) "(?P<request>.+)" "(?P<user_agent>.+)" (?P<ssl_cipher>.+) (?P<ssl_protocol>.+) (?P<target_group_arn>.+) "Root=(?P<trace_id>.+)" "(?P<domain_name>.+)" "(?P<chosen_cert_arn>.+)" (?P<matched_rule_priority>.+) (?P<request_creation_time>.+) "(?P<actions_executed>.+)" "(?P<redirect_url>.+)" "(?P<error_reason>.+)"'
           HONEYCOMB_WRITE_KEY: !Ref HoneycombWriteKey
           KMS_KEY_ID: !Ref KMSKeyId
           API_HOST: !Ref HoneycombAPIHost


### PR DESCRIPTION
AWS added 5 new fields to the access log entry:

Field | Description
--- | ---
matched_rule_priority | The priority value of the rule that matched the request. If a rule matched, this is a value from 1 to 50,000. If no rule matched and the default action was taken, this value is set to 0. If an error occurs during rules evaluation, it is set to -1. For any other error, it is set to -.
request_creation_time | The time when the load balancer received the request from the client, in ISO 8601 format.
"actions_executed" | The actions taken when processing the request, enclosed in double quotes. This value is a comma-separated list that can include the values described in Actions Taken. If no action was taken, such as for a malformed request, this value is set to -.
"redirect_url" | The URL of the redirect target for the location header of the HTTP response, enclosed in double quotes. If no redirect actions were taken, this value is set to -.
"error_reason" | The error reason code, enclosed in double quotes. If the request failed, this is one of the error codes described in Error Reason Codes. If the actions taken do not include an authenticate action or the target is not a Lambda function, this value is set to -.

Because of this, the regex failed to parse the log and broke the fields in Honeycomb UI

I added the missing fields and all looks good now. 

Fixes https://github.com/honeycombio/agentless-integrations-for-aws/issues/19

