### PR TITLE
fix missing continue which should skip on invalid payload

### DIFF
--- a/publisher/main.go
+++ b/publisher/main.go
@@ -80,6 +80,7 @@ func Handler(request events.CloudwatchLogsEvent) (Response, error) {
 		if err != nil {
 			logrus.WithError(err).WithField("line", event.Message).
 				Warn("unable to get event payload from line, skipping")
+			continue
 		}
 		hnyEvent := libhoney.NewEvent()
 		// add the actual event data


### PR DESCRIPTION
I believe this should fix a panic which occurs when it attempts to read `payload.data` a couple of lines below this.