### PR TITLE
Improve ALB logs regex

### DIFF
--- a/templates/aws-alb-logs.yml
+++ b/templates/aws-alb-logs.yml
@@ -82,7 +82,7 @@ Resources:
         Variables:
           ENVIRONMENT: !Ref Environment
           PARSER_TYPE: regex
-          REGEX_PATTERN: '(?P<type>.+) (?P<timestamp>.+) (?P<elb>.+) (?P<client>.+) (?P<target>.+) (?P<request_processing_time>.+) (?P<target_processing_time>.+) (?P<response_processing_time>.+) (?P<elb_status_code>.+) (?P<target_status_code>.+) (?P<received_bytes>.+) (?P<sent_bytes>.+) "(?P<request>.+)" "(?P<user_agent>.+)" (?P<ssl_cipher>.+) (?P<ssl_protocol>.+) (?P<target_group_arn>.+) "Root=(?P<trace_id>.+)" "(?P<domain_name>.+)" "(?P<chosen_cert_arn>.+)" (?P<matched_rule_priority>.+) (?P<request_creation_time>.+) "(?P<actions_executed>.+)" "(?P<redirect_url>.+)" "(?P<error_reason>.+)"'
+          REGEX_PATTERN: '(?P<type>[^ ]+) (?P<timestamp>[^ ]+) (?P<elb>[^ ]+) (?P<client>[^ ]+) (?P<target>[^ ]+) (?P<request_processing_time>[^ ]+) (?P<target_processing_time>[^ ]+) (?P<response_processing_time>[^ ]+) (?P<elb_status_code>[^ ]+) (?P<target_status_code>[^ ]+) (?P<received_bytes>[^ ]+) (?P<sent_bytes>[^ ]+) "(?P<request>[^"]+)" "(?P<user_agent>[^"]+)" (?P<ssl_cipher>[^ ]+) (?P<ssl_protocol>[^ ]+) (?P<target_group_arn>[^ ]+) "Root=(?P<trace_id>[^"]+)" "(?P<domain_name>[^"]+)" "(?P<chosen_cert_arn>[^"]+)" (?P<matched_rule_priority>[^ ]+) (?P<request_creation_time>[^ ]+) "(?P<actions_executed>[^"]+)" "(?P<redirect_url>[^"]+)" "(?P<error_reason>[^"]+)" "(?P<target_list>[^"]+)" "(?P<target_status_code_list>[^"]+)"'
           HONEYCOMB_WRITE_KEY: !Ref HoneycombWriteKey
           KMS_KEY_ID: !Ref KMSKeyId
           API_HOST: !Ref HoneycombAPIHost


### PR DESCRIPTION
Similar to #24, the ALB logs have added a couple more fields so parsing was broken again. I've added those fields, and I've also changed the `.`s to be more specific, which may improve performance (it did dramatically when I tested it in python but I didn't test it in go) and also seemed to actually help get it to match as well(?). This doesn't handle e.g. escaped quotes in quoted fields, but I haven't seen that come up.

Worth noting that log fields are always added to the end and AWS recommends writing parsers to not fail if there's extra fields at the end for forward-compatibility; I wasn't sure how to accomplish that but it would be a good change.

Edit: I've also just noticed that the ALB logs sometimes do have more than just a root in the `X-Amzn-Trace-Id` header, which breaks both master and my PR. I've written a fix for it, but I accidentally deleted my fork and don't seem to be able to link it back up to this PR. The fix is here: https://github.com/nbouscal/agentless-integrations-for-aws/commit/eac1355e283a92a0e4772ea10e11c44fc2522d1d