### PR TITLE
[postgresql] fix sample_rate, allow configuration of log_line_prefix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -e
 
 ./test.sh
 
-VERSION=2.0.3
+VERSION=2.0.4
 REGIONS="us-east-1 us-east-2 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1"
 
 ROOT_DIR=$(pwd)

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -e
 
 ./test.sh
 
-VERSION=2.0.4
+VERSION=2.1.0
 REGIONS="us-east-1 us-east-2 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1"
 
 ROOT_DIR=$(pwd)

--- a/common/common.go
+++ b/common/common.go
@@ -28,7 +28,7 @@ var (
 )
 
 const (
-	version = "2.0.4"
+	version = "2.1.0"
 )
 
 // InitHoneycombFromEnvVars will attempt to call libhoney.Init based on values

--- a/common/common.go
+++ b/common/common.go
@@ -28,7 +28,7 @@ var (
 )
 
 const (
-	version = "2.0.3"
+	version = "2.0.4"
 )
 
 // InitHoneycombFromEnvVars will attempt to call libhoney.Init based on values

--- a/postgresql-handler/main.go
+++ b/postgresql-handler/main.go
@@ -109,8 +109,10 @@ func main() {
 	}
 	defer libhoney.Close()
 
+	logLinePrefix := os.Getenv("LOG_LINE_PREFIX")
+
 	parser = &postgresql.Parser{}
-	parser.Init(&postgresql.Options{})
+	parser.Init(&postgresql.Options{LogLinePrefix: logLinePrefix})
 
 	common.AddUserAgentMetadata("rds", "postgresql")
 

--- a/postgresql-handler/main.go
+++ b/postgresql-handler/main.go
@@ -73,7 +73,6 @@ func Handler(request events.CloudwatchLogsEvent) (Response, error) {
 			}
 			hnyEvent.Add(e.Data)
 			hnyEvent.Timestamp = e.Timestamp
-			hnyEvent.SampleRate = uint(e.SampleRate)
 			if env != "" {
 				hnyEvent.AddField("env", env)
 			}

--- a/postgresql-handler/main.go
+++ b/postgresql-handler/main.go
@@ -81,8 +81,8 @@ func Handler(request events.CloudwatchLogsEvent) (Response, error) {
 			for _, field := range common.GetFilterFields() {
 				delete(fields, field)
 			}
-			// Sampling is done in the parser for greater efficiency
-			hnyEvent.SendPresampled()
+
+			hnyEvent.Send()
 		}
 		wg.Done()
 	}()

--- a/templates/cloudwatch-rds-postgresql.yml
+++ b/templates/cloudwatch-rds-postgresql.yml
@@ -24,6 +24,10 @@ Parameters:
     Type: Number
     Default: 1
     Description: Sample rate. See https://honeycomb.io/docs/guides/sampling/.
+  LogLinePrefix:
+    Type: Number
+    Default: '%t [%p-%l] %u@%d'
+    Description: The prefix of each log line. See https://www.postgresql.org/docs/current/runtime-config-logging.html#GUC-LOG-LINE-PREFIX
   LogGroupName:
     Type: String
     Description: The name of the AWS Cloudwatch Log Group to subscribe to
@@ -75,6 +79,7 @@ Metadata:
       - Label:
           default: Optional Parameters
         Parameters:
+          - LogLinePrefix
           - LogGroupName1
           - LogGroupName2
           - LogGroupName3
@@ -115,6 +120,7 @@ Resources:
           DATASET: !Ref HoneycombDataset
           SAMPLE_RATE: !Ref HoneycombSampleRate
           SCRUB_QUERY: !Ref ScrubQuery
+          LOG_LINE_PREFIX: !Ref LogLinePrefix
           FILTER_FIELDS: !Ref FilterFields
       FunctionName:
         "Fn::Join":

--- a/templates/cloudwatch-rds-postgresql.yml
+++ b/templates/cloudwatch-rds-postgresql.yml
@@ -25,7 +25,7 @@ Parameters:
     Default: 1
     Description: Sample rate. See https://honeycomb.io/docs/guides/sampling/.
   LogLinePrefix:
-    Type: Number
+    Type: String
     Default: '%t [%p-%l] %u@%d'
     Description: The prefix of each log line. See https://www.postgresql.org/docs/current/runtime-config-logging.html#GUC-LOG-LINE-PREFIX
   LogGroupName:


### PR DESCRIPTION
Bumps to 2.1.0

The postgres handler sends events with `SendPresampled`, assuming the postgres parser is doing the sampling. I think this was some copy-pasta from the mysql implementation. THe postgresql parser doesn't currently do sampling, but the mysql parser does.

Calling `Send()` will use the sample rate initialized in libhoney, which is set in the SAMPLE_RATE env var read in by InitHoneycombFromEnvVars.

Also enables `log_line_prefix` to be set from the CFN template via env variable