### PR TITLE
remove EncryptionEnabled clause from LambdaS3Policy in templates

### DIFF
--- a/templates/aws-alb-logs.yml
+++ b/templates/aws-alb-logs.yml
@@ -165,7 +165,6 @@ Resources:
                   - !Ref KMSKeyId
   LambdaS3Policy:
     Type: "AWS::IAM::Policy"
-    Condition: EncryptionEnabled
     Properties:
       PolicyName: "lambda-s3-getobject"
       Roles:

--- a/templates/aws-elb-logs.yml
+++ b/templates/aws-elb-logs.yml
@@ -165,7 +165,6 @@ Resources:
                   - !Ref KMSKeyId
   LambdaS3Policy:
     Type: "AWS::IAM::Policy"
-    Condition: EncryptionEnabled
     Properties:
       PolicyName: "lambda-s3-getobject"
       Roles:

--- a/templates/s3-bucket-logs.yml
+++ b/templates/s3-bucket-logs.yml
@@ -153,7 +153,6 @@ Resources:
                   - !Ref KMSKeyId
   LambdaS3Policy:
     Type: "AWS::IAM::Policy"
-    Condition: EncryptionEnabled
     Properties:
       PolicyName: "lambda-s3-getobject"
       Roles:


### PR DESCRIPTION
This mistakenly limted the S3 bucket policy configuration to builds that utilized the KMS-encrypted API key, but that was done in error and I think just copied around to other templates. :(