### PR TITLE
[publisher] don't try to parse default START, END, REPORTER log lines

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -e
 
 ./test.sh
 
-VERSION=2.1.0
+VERSION=2.1.1
 REGIONS="us-east-1 us-east-2 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1"
 
 ROOT_DIR=$(pwd)

--- a/common/common.go
+++ b/common/common.go
@@ -28,7 +28,7 @@ var (
 )
 
 const (
-	version = "2.1.0"
+	version = "2.1.1"
 )
 
 // InitHoneycombFromEnvVars will attempt to call libhoney.Init based on values

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -31,3 +31,23 @@ func TestExtractPayload(t *testing.T) {
 		t.Error("unexpected value for time: ", payload.time)
 	}
 }
+
+func TestLambdaReportLineRegexp(t *testing.T) {
+	lines := []string{
+		"START RequestId: 2c2768b7-136f-4218-a4d9-07b7a4620051 Version: $LATEST\n",
+		"END RequestId: 525c23de-e7e1-4cbe-a3ee-78f43f45410b\n",
+		"REPORT RequestId: 2c2768b7-136f-4218-a4d9-07b7a4620051 Duration: 488.98 ms Billed Duration: 500 ms Memory Size: 3008 MB Max Memory Used: 84 MB Init Duration: 186.91 ms\n",
+	}
+
+	for _, line := range lines {
+		match := lambdaReportLineRegex.FindString(line)
+		if match == "" {
+			t.Error("expected match, line = ", line)
+		}
+	}
+
+	match := lambdaReportLineRegex.FindString(`{"a":"json", "line": true}`)
+	if match != "" {
+		t.Error("lambda report pattern should not match json")
+	}
+}


### PR DESCRIPTION
I considered making this a configurable option, but the publisher only works with JSON, and the only output it's supposed to work with is our event data, so there's no reason we should need to worry about other data with this format ever being "valid".