### PR TITLE
Add cw logs metadata to mysql/postgresql handler

### DIFF
--- a/mysql-handler/main.go
+++ b/mysql-handler/main.go
@@ -81,9 +81,9 @@ func Handler(request events.CloudwatchLogsEvent) (Response, error) {
 				delete(fields, field)
 			}
 			// Add CloudWatch event metadata
-			hnyEvent.AddField("cw_log_group", data.LogGroup)
-			hnyEvent.AddField("cw_log_stream", data.LogStream)
-			hnyEvent.AddField("cw_owner", data.Owner)
+			hnyEvent.AddField("aws.cloudwatch.group", data.LogGroup)
+			hnyEvent.AddField("aws.cloudwatch.stream", data.LogStream)
+			hnyEvent.AddField("aws.cloudwatch.owner", data.Owner)
 			// Sampling is done in the parser for greater efficiency
 			hnyEvent.SendPresampled()
 		}

--- a/mysql-handler/main.go
+++ b/mysql-handler/main.go
@@ -80,6 +80,10 @@ func Handler(request events.CloudwatchLogsEvent) (Response, error) {
 			for _, field := range common.GetFilterFields() {
 				delete(fields, field)
 			}
+			// Add CloudWatch event metadata
+			hnyEvent.AddField("cw_log_group", data.LogGroup)
+			hnyEvent.AddField("cw_log_stream", data.LogStream)
+			hnyEvent.AddField("cw_owner", data.Owner)
 			// Sampling is done in the parser for greater efficiency
 			hnyEvent.SendPresampled()
 		}

--- a/postgresql-handler/main.go
+++ b/postgresql-handler/main.go
@@ -80,6 +80,10 @@ func Handler(request events.CloudwatchLogsEvent) (Response, error) {
 			for _, field := range common.GetFilterFields() {
 				delete(fields, field)
 			}
+			// Add CloudWatch event metadata
+			hnyEvent.AddField("cw_log_group", data.LogGroup)
+			hnyEvent.AddField("cw_log_stream", data.LogStream)
+			hnyEvent.AddField("cw_owner", data.Owner)
 
 			hnyEvent.Send()
 		}

--- a/postgresql-handler/main.go
+++ b/postgresql-handler/main.go
@@ -81,9 +81,9 @@ func Handler(request events.CloudwatchLogsEvent) (Response, error) {
 				delete(fields, field)
 			}
 			// Add CloudWatch event metadata
-			hnyEvent.AddField("cw_log_group", data.LogGroup)
-			hnyEvent.AddField("cw_log_stream", data.LogStream)
-			hnyEvent.AddField("cw_owner", data.Owner)
+			hnyEvent.AddField("aws.cloudwatch.group", data.LogGroup)
+			hnyEvent.AddField("aws.cloudwatch.stream", data.LogStream)
+			hnyEvent.AddField("aws.cloudwatch.owner", data.Owner)
 
 			hnyEvent.Send()
 		}


### PR DESCRIPTION
Add cloudwatch log group, log stream and cloudwatch owner metadata do
mysql and postgresql agentless integration handlers.

This can be very useful for figuring out where the logs are coming from,
for example the account name (owner field), or extracting the database
name from the log group name on Honeycomb's.

Also now that events can be arbitrarly large (up to a limit of 100KB)
this shouldn't be affect billing either, so the more (meta)data, the
better!