### PR TITLE
Update and fix S3 bucket log regex

### DIFF
--- a/templates/s3-bucket-logs.yml
+++ b/templates/s3-bucket-logs.yml
@@ -72,7 +72,7 @@ Resources:
         Variables:
           ENVIRONMENT: !Ref Environment
           PARSER_TYPE: regex
-          REGEX_PATTERN: '(?P<bucket_owner>.+) (?P<bucket>.+) \[(?P<timestamp>.+)\] (?P<remote_ip>.+) (?P<requester>.+) (?P<request_id>.+) (?P<operation>.+) (?P<key>.+) "(?P<request_uri>.+)" (?P<http_status>.+) (?P<error_code>.+) (?P<bytes_sent>.+) (?P<object_size>.+) (?P<total_time>.+) (?P<turnaround_time>.+) "(?P<referrer>.+)" "(?P<user_agent>.+)" (?P<version_id>.+)'
+          REGEX_PATTERN: '(?P<bucket_owner>[^\s]+) (?P<bucket>[^\s]+) \[(?P<timestamp>.+?)\] (?P<remote_ip>[^\s]+) (?P<requester>[^\s]+) (?P<request_id>[^\s]+) (?P<operation>[^\s]+) (?P<key>[^\s]+) "(?P<request_uri>.+?)" (?P<http_status>[^\s]+) (?P<error_code>[^\s]+) (?P<bytes_sent>[^\s]+) (?P<object_size>[^\s]+) (?P<total_time>[^\s]+) (?P<turnaround_time>[^\s]+) "(?P<referrer>.+?)" "(?P<user_agent>.+?)" (?P<version_id>[^\s]+) (?P<host_id>[^\s]+) (?P<signature_version>[^\s]+) (?P<cipher_suite>[^\s]+) (?P<auth_type>[^\s]+) (?P<host_header>[^\s]+) (?P<tls_version>[^\s]+)'
           HONEYCOMB_WRITE_KEY: !Ref HoneycombWriteKey
           KMS_KEY_ID: !Ref KMSKeyId
           API_HOST: !Ref HoneycombAPIHost


### PR DESCRIPTION
This change:
- Incorporates new S3 bucket log fields into the regex pattern.
- Ensures future compatibility with changes to the S3 bucket log format.

The additional fields are as per <https://docs.aws.amazon.com/AmazonS3/latest/dev/LogFormat.html>.

[AWS may add new fields to the bucket logs at any time.](https://docs.aws.amazon.com/AmazonS3/latest/dev/LogFormat.html#LogFormatExtensible) Prior to this PR, the `version_id` field matches all of the new fields due to greedy matching. By matching anything except a space, this can be avoided.

Examples:
- Old pattern - https://regex101.com/r/ry8fdY/1
- New pattern - https://regex101.com/r/iZ0rjW/1
- New pattern with extra fields - https://regex101.com/r/j8rMzQ/1