### PR TITLE
Fix kms secret decryption

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -73,7 +73,7 @@ func InitHoneycombFromEnvVars() error {
 				logrus.WithError(err).Error("unable to decrypt honeycomb write key")
 				return fmt.Errorf("unable to decrypt honeycomb write key")
 			}
-			writeKey = string(resp.Plaintext)
+			writeKey = base64.StdEncoding.EncodeToString(resp.Plaintext)
 		}
 	} else {
 		writeKey = os.Getenv("HONEYCOMB_WRITE_KEY")


### PR DESCRIPTION
There seems to be a bug when using a KMS encrypted write key. This change will encode the response from KMS back to a string rather than typecasting it to a string.

I have tested this using `s3-handler`.