### PR TITLE
update CI to release and publish on taggings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,20 @@ jobs:
             - pkg
       - store_artifacts:
           path: ./pkg
+  publish_aws:
+    executor: go
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - aws-cli/setup:
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          aws-region: AWS_REGION
+      - run:
+          command: ./publish_aws.sh
+          environment:
+            DRYRUN: true # remove this before merging
 
 # Orchestrate or schedule a set of jobs, see https://circleci.com/docs/2.0/workflows/
 workflows:
@@ -73,4 +87,10 @@ workflows:
           <<: *filters_always
           requires:
             - go_test
-      # TODO add publish here
+      - publish_aws:
+          <<: *filters_always # change to filters_publish before merging
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - validate_templates
+            - build
+      # TODO add publish_github here?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,25 @@
 # Use the latest 2.1 version of CircleCI pipeline processing engine, see https://circleci.com/docs/2.0/configuration-reference/
 version: 2.1
 
+# YAML Anchors to reduce copypasta
+
+# This is necessary for job to run when a tag is created
+filters_always: &filters_always
+  filters:
+    tags:
+      only: /.*/
+
+# Restrict running to only be on tags starting with vNNNN
+filters_publish: &filters_publish
+  filters:
+    tags:
+      only: /^v[0-9].*/
+    branches:
+      ignore: /.*/
+
+orbs:
+  aws-cli: circleci/aws-cli@2.0.3
+
 executors:
   go:
     parameters:
@@ -12,18 +31,31 @@ executors:
       - image: circleci/golang:1.<< parameters.goversion >>
 
 jobs:
-  run_tests:
+  go_test:
     executor: go
     steps:
       - checkout
-      # TODO also validate templates
       - run: go get -v -t -d ./...
       - run: go test -v ./...
+  validate_templates:
+    executor: go
+    steps:
+      - checkout
+      - aws-cli/setup:
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          aws-region: AWS_REGION
+      - run: ./test.sh
 
 # Orchestrate or schedule a set of jobs, see https://circleci.com/docs/2.0/workflows/
 workflows:
   version: 2
-  run_tests:
+  build:
     jobs:
-      - run_tests
+      - go_test:
+          <<: *filters_always
+      - validate_templates:
+          <<: *filters_always
+          # Testing templates requires AWS API access; no changes are made
+          context: Honeycomb Secrets for Public Repos
       # TODO build and deploy here

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,10 +67,7 @@ jobs:
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
           aws-region: AWS_REGION
-      - run:
-          command: ./publish_aws.sh
-          environment:
-            DRYRUN: true # remove this before merging
+      - run: ./publish_aws.sh
 
 # Orchestrate or schedule a set of jobs, see https://circleci.com/docs/2.0/workflows/
 workflows:
@@ -88,7 +85,7 @@ workflows:
           requires:
             - go_test
       - publish_aws:
-          <<: *filters_always # change to filters_publish before merging
+          <<: *filters_publish
           context: Honeycomb Secrets for Public Repos
           requires:
             - validate_templates

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,17 @@ jobs:
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
           aws-region: AWS_REGION
       - run: ./test.sh
+  build:
+    executor: go
+    steps:
+      - checkout
+      - run: ./build.sh
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - pkg
+      - store_artifacts:
+          path: ./pkg
 
 # Orchestrate or schedule a set of jobs, see https://circleci.com/docs/2.0/workflows/
 workflows:
@@ -58,4 +69,8 @@ workflows:
           <<: *filters_always
           # Testing templates requires AWS API access; no changes are made
           context: Honeycomb Secrets for Public Repos
-      # TODO build and deploy here
+      - build:
+          <<: *filters_always
+          requires:
+            - go_test
+      # TODO add publish here

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,17 @@ jobs:
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
           aws-region: AWS_REGION
       - run: ./publish_aws.sh
+  publish_github:
+    docker:
+      - image: cibuilds/github:0.13.0
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run:
+          name: "Draft GitHub Release"
+          command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./pkg/ingest-handlers.zip
+
 
 # Orchestrate or schedule a set of jobs, see https://circleci.com/docs/2.0/workflows/
 workflows:
@@ -90,4 +101,9 @@ workflows:
           requires:
             - validate_templates
             - build
-      # TODO add publish_github here?
+      - publish_github:
+          <<: *filters_publish
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - validate_templates
+            - build

--- a/build.sh
+++ b/build.sh
@@ -3,9 +3,12 @@
 
 set -e
 
-./test.sh
-
-VERSION=2.2.1
+# A fallback version when run outside of CI. Will look like: 2.2.1-13-gd591456
+# 2.2.1 - most recent tag with the leading v trimmed
+# 13 - no.of commits away from tag
+# gd591456 - this commit's id
+GIT_VERSION="`git describe | sed -e s/^v//`"
+VERSION="${CIRCLE_TAG:-$GIT_VERSION}"
 REGIONS="us-east-1 us-east-2 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1"
 
 ROOT_DIR=$(pwd)
@@ -16,7 +19,7 @@ HANDLERS="cloudwatch-handler s3-handler sns-handler mysql-handler postgresql-han
 
 for HANDLER in ${HANDLERS}; do
 	cd ${HANDLER}
-	GOOS=linux go build
+	GOOS=linux go build -ldflags "-X github.com/honeycombio/agentless-integrations-for-aws/common.version=${VERSION}"
 	cd ${ROOT_DIR}
 	mv ${HANDLER}/${HANDLER} pkg
 done;

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages handlers and ships them to S3 for use in templates
+# packages handlers
 
 set -e
 
@@ -9,7 +9,6 @@ set -e
 # gd591456 - this commit's id
 GIT_VERSION="`git describe | sed -e s/^v//`"
 VERSION="${CIRCLE_TAG:-$GIT_VERSION}"
-REGIONS="us-east-1 us-east-2 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1"
 
 ROOT_DIR=$(pwd)
 rm -rf pkg
@@ -27,19 +26,3 @@ done;
 cd ./pkg
 
 zip ingest-handlers.zip *
-
-for REGION in ${REGIONS}; do
-	DEPLOY_ROOT=s3://honeycomb-integrations-${REGION}/agentless-integrations-for-aws
-	aws s3 cp ingest-handlers.zip ${DEPLOY_ROOT}/LATEST/ingest-handlers.zip
-	aws s3 cp ingest-handlers.zip ${DEPLOY_ROOT}/${VERSION}/ingest-handlers.zip
-done;
-
-cd ${ROOT_DIR}
-
-# publish the templates to our builds bucket
-DEPLOY_ROOT=s3://honeycomb-builds/honeycombio/integrations-for-aws
-
-for TEMPLATE in templates/*; do
-	aws s3 cp ${TEMPLATE} ${DEPLOY_ROOT}/LATEST/${TEMPLATE}
-	aws s3 cp ${TEMPLATE} ${DEPLOY_ROOT}/${VERSION}/${TEMPLATE}
-done

--- a/common/common.go
+++ b/common/common.go
@@ -25,10 +25,7 @@ var (
 	dataset      string
 	errorDataset string
 	filterFields []string
-)
-
-const (
-	version = "2.2.1"
+	version = "dev"
 )
 
 // InitHoneycombFromEnvVars will attempt to call libhoney.Init based on values

--- a/publish_aws.sh
+++ b/publish_aws.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# ships handlers to S3 for use in templates
+
+set -e
+
+# A fallback version when run outside of CI. Will look like: 2.2.1-13-gd591456
+# 2.2.1 - most recent tag with the leading v trimmed
+# 13 - no.of commits away from tag
+# gd591456 - this commit's id
+GIT_VERSION="`git describe | sed -e s/^v//`"
+VERSION="${CIRCLE_TAG:-$GIT_VERSION}"
+REGIONS="us-east-1 us-east-2 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1"
+
+ZIP_NAME="ingest-handlers.zip"
+ZIP_PATH="./pkg/${ZIP_NAME}"
+
+if [[ -f "${ZIP_PATH}" ]]; then
+  echo "+++ Publishing ${ZIP_PATH} to S3"
+else
+  echo 1>&2 "$ZIP_PATH does not exist. Run build.sh?"
+	exit 1
+fi
+
+# if DRYRUN is set to anything, turn it into the awscli switch
+[[ -n "${DRYRUN}" ]] && DRYRUN="--dryrun"
+
+echo "+++ Uploading handlers"
+for REGION in ${REGIONS}; do
+	DEPLOY_ROOT=s3://honeycomb-integrations-${REGION}/agentless-integrations-for-aws
+	aws s3 cp ${DRYRUN} ${ZIP_PATH} ${DEPLOY_ROOT}/LATEST/${ZIP_NAME}
+	aws s3 cp ${DRYRUN} ${ZIP_PATH} ${DEPLOY_ROOT}/${VERSION}/${ZIP_NAME}
+done
+
+# publish the templates to our builds bucket
+DEPLOY_ROOT=s3://honeycomb-builds/honeycombio/integrations-for-aws
+
+echo "+++ Uploading templates"
+for TEMPLATE in templates/*; do
+	aws s3 cp ${DRYRUN} ${TEMPLATE} ${DEPLOY_ROOT}/LATEST/${TEMPLATE}
+	aws s3 cp ${DRYRUN} ${TEMPLATE} ${DEPLOY_ROOT}/${VERSION}/${TEMPLATE}
+done

--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,8 @@
 # quickly validate that templates are valid
 
 set -e
-
+export AWS_PAGER=""
 for TEMPLATE in templates/*.yml; do
-    aws cloudformation validate-template --template-body=file://./${TEMPLATE}
+    aws cloudformation validate-template --template-body=file://./${TEMPLATE} \
+    && echo "${TEMPLATE} parses OK."
 done;


### PR DESCRIPTION
- [x] add CloudFormation template validation to CI tests
- [x] build the handlers and zipfile if all tests pass
- [x] publish to AWS
- [x] publish to GitHub Release
---
- [x] add CI user to repo
- ~turn off validate_templates job on forks, maybe?~ Punting. Not a big problem right now.