### PR TITLE
Allow dependabot and forked PRs to run in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,13 @@ workflows:
       - go_test:
           <<: *filters_always
       - validate_templates:
-          <<: *filters_always
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore:
+                - /pull\/.*/
+                - /dependabot\/.*/
           # Testing templates requires AWS API access; no changes are made
           context: Honeycomb Secrets for Public Repos
       - build:


### PR DESCRIPTION
dependabot and outside collaborators don't have access to CI secrets -- don't run `validate_templates` for those builds