### PR TITLE
maint: use latest go version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,10 @@ executors:
     parameters:
       goversion:
         type: string
-        default: "12"
+        default: "17"
     working_directory: /go/src/github.com/honeycombio/agentless-integrations-for-aws
     docker:
-      - image: circleci/golang:1.<< parameters.goversion >>
+      - image: cimg/go:1.<< parameters.goversion >>
 
 jobs:
   go_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ executors:
       goversion:
         type: string
         default: "17"
-    working_directory: /go/src/github.com/honeycombio/agentless-integrations-for-aws
+    working_directory: /home/circleci/go/src/github.com/honeycombio/agentless-integrations-for-aws
     docker:
       - image: cimg/go:1.<< parameters.goversion >>
 


### PR DESCRIPTION
closes #39 