### PR TITLE
[fix] Revert "fix kms secret decryption"

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -70,7 +70,7 @@ func InitHoneycombFromEnvVars() error {
 				logrus.WithError(err).Error("unable to decrypt honeycomb write key")
 				return fmt.Errorf("unable to decrypt honeycomb write key")
 			}
-			writeKey = base64.StdEncoding.EncodeToString(resp.Plaintext)
+			writeKey = string(resp.Plaintext)
 		}
 	} else {
 		writeKey = os.Getenv("HONEYCOMB_WRITE_KEY")


### PR DESCRIPTION
This reverts commit aa46d170f22f645d0249c4de6040d03d21f2ba5b.

<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- When using an encrypted API key via a KMS key, Cloudwatch logs were not being sent to Honeycomb.

## Short description of the changes

- #34 had been created to handle the decrypted key, but seems it actually was encoding the string to Base64 instead of providing a string of the key, which is needed. By changing this back to string, the decrypted key works in properly sending events to Honeycomb.

