### PR TITLE
fix: alb logs are not parsed

### DIFF
--- a/templates/aws-alb-logs.yml
+++ b/templates/aws-alb-logs.yml
@@ -93,6 +93,7 @@ Resources:
           MATCH_PATTERNS: !Ref MatchPatterns
           FILTER_PATTERNS: !Ref FilterPatterns
           FILTER_FIELDS: !Ref FilterFields
+          FORCE_GUNZIP: true
       FunctionName:
         "Fn::Join":
           - '-'


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- ALB access logs are gzipped, but don't get the right content-encoding when uploaded to S3
- the s3-handler (used by ALB template) assumes contents are already uncompressed, because that happens in the aws-sdk with correct content-encoding
- #23 made the change to trust the content-encoding
- closes #96 

## Short description of the changes

- add the forced uncompression to the ALB template: the logs files should always be gzipped based on [AWS docs](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-log-file-format)
- with `FORCE_GUNZIP` if the handler fails to read the body with gzip, it will fall back to just reading it as plain text

Didn't verify this issue in other integrations besides ALB, will add a separate issue to do that.

