### PR TITLE
maint: update ci image to cimg/go1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ executors:
     parameters:
       goversion:
         type: string
-        default: "17"
+        default: "18"
     working_directory: /home/circleci/go/src/github.com/honeycombio/agentless-integrations-for-aws
     docker:
       - image: cimg/go:1.<< parameters.goversion >>


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #107 

## Short description of the changes

- update ci image to cimg/go1.18 (which is currently on 1.18.1)

