### PR TITLE
abstract trace manipulation into albevent; add ALIAS_FIELDS feature

### DIFF
--- a/.github/workflows/s3-handler-validations.yml
+++ b/.github/workflows/s3-handler-validations.yml
@@ -1,5 +1,7 @@
 name: Validate s3-handler
-on: [push]
+on:
+  - pull_request
+  - push
 jobs:
   s3-handler-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/s3-handler-validations.yml
+++ b/.github/workflows/s3-handler-validations.yml
@@ -1,0 +1,12 @@
+name: Validate s3-handler
+on: [push]
+jobs:
+  s3-handler-tests:
+    runs-on: ubuntu-latest
+    container:
+      image: golang:1.19.0
+      options: --cpus 1
+    steps:
+      - uses: actions/checkout@v3
+      - run: go test ./...
+        working-directory: ./s3-handler

--- a/common/common.go
+++ b/common/common.go
@@ -205,7 +205,7 @@ func GetFilterFields() []string {
 
 func GetRenameFields() map[string]string {
 	if renameFields == nil {
-		renameFields, _ = fieldMappingsFrom("RENAME_FIELDS")
+		renameFields, _ = getFieldMappings("RENAME_FIELDS")
 	}
 
 	return renameFields
@@ -213,7 +213,7 @@ func GetRenameFields() map[string]string {
 
 func GetAliasFields() map[string]string {
 	if aliasFields == nil {
-		aliasFields, _ = fieldMappingsFrom("ALIAS_FIELDS")
+		aliasFields, _ = getFieldMappings("ALIAS_FIELDS")
 	}
 
 	return aliasFields
@@ -251,7 +251,7 @@ func readResponses(responses chan transmission.Response) {
 	}
 }
 
-func fieldMappingsFrom(environmentName string) (map[string]string, error) {
+func getFieldMappings(environmentName string) (map[string]string, error) {
 	var mappings = map[string]string{}
 
 	if os.Getenv(environmentName) != "" {

--- a/common/common.go
+++ b/common/common.go
@@ -32,7 +32,10 @@ var (
 	version      = "dev"
 )
 
-func ClearCache() {
+// ClearFieldMappingCache will reset the cached map[string]string values for the
+// alias, filter and rename fields. This is primarily used in testing so that static
+// data does not undesirably bleed into different test runs.
+func ClearFieldMappingCache() {
 	aliasFields = nil
 	filterFields = nil
 	renameFields = nil

--- a/common/common.go
+++ b/common/common.go
@@ -257,8 +257,8 @@ func readResponses(responses chan transmission.Response) {
 func getFieldMappings(environmentName string) (map[string]string, error) {
 	var mappings = map[string]string{}
 
-	if os.Getenv(environmentName) != "" {
-		fieldsConfig := strings.Split(os.Getenv(environmentName), ",")
+	if envVal := os.Getenv(environmentName); envVal != "" {
+		fieldsConfig := strings.Split(envVal, ",")
 		for _, kv := range fieldsConfig {
 			kvPair := strings.Split(kv, "=")
 

--- a/common/common.go
+++ b/common/common.go
@@ -208,7 +208,7 @@ func GetFilterFields() []string {
 
 func GetRenameFields() map[string]string {
 	if renameFields == nil {
-		renameFields, _ = getFieldMappings("RENAME_FIELDS")
+		renameFields = getFieldMappings("RENAME_FIELDS")
 	}
 
 	return renameFields
@@ -216,7 +216,7 @@ func GetRenameFields() map[string]string {
 
 func GetAliasFields() map[string]string {
 	if aliasFields == nil {
-		aliasFields, _ = getFieldMappings("ALIAS_FIELDS")
+		aliasFields = getFieldMappings("ALIAS_FIELDS")
 	}
 
 	return aliasFields
@@ -254,7 +254,7 @@ func readResponses(responses chan transmission.Response) {
 	}
 }
 
-func getFieldMappings(environmentName string) (map[string]string, error) {
+func getFieldMappings(environmentName string) map[string]string {
 	var mappings = map[string]string{}
 
 	if envVal := os.Getenv(environmentName); envVal != "" {
@@ -272,5 +272,5 @@ func getFieldMappings(environmentName string) (map[string]string, error) {
 		}
 	}
 
-	return mappings, nil
+	return mappings
 }

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -3,6 +3,8 @@ package common
 import (
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetFilterFields(t *testing.T) {
@@ -28,4 +30,28 @@ func TestGetFilterFields(t *testing.T) {
 	if fields[2] != "c" {
 		t.Error("wrong value in GetFilterFields result")
 	}
+}
+
+func TestGetRenameFields(t *testing.T) {
+	ClearCache()
+
+	t.Setenv("RENAME_FIELDS", "trace_id=trace.trace_id,span_id=trace.span_id")
+
+	expected := map[string]string{"trace_id": "trace.trace_id", "span_id": "trace.span_id"}
+	assert.Equal(t, expected, GetRenameFields())
+
+	t.Setenv("RENAME_FIELDS", "cached=value")
+	assert.Equal(t, expected, GetRenameFields())
+}
+
+func TestGetAliasFields(t *testing.T) {
+	ClearCache()
+
+	t.Setenv("ALIAS_FIELDS", "trace_id=trace.trace_id,span_id=trace.span_id")
+
+	expected := map[string]string{"trace_id": "trace.trace_id", "span_id": "trace.span_id"}
+	assert.Equal(t, expected, GetAliasFields())
+
+	t.Setenv("ALIAS_FIELDS", "cached=value")
+	assert.Equal(t, expected, GetAliasFields())
 }

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -33,7 +33,7 @@ func TestGetFilterFields(t *testing.T) {
 }
 
 func TestGetRenameFields(t *testing.T) {
-	ClearCache()
+	ClearFieldMappingCache()
 
 	t.Setenv("RENAME_FIELDS", "trace_id=trace.trace_id,span_id=trace.span_id")
 
@@ -45,7 +45,7 @@ func TestGetRenameFields(t *testing.T) {
 }
 
 func TestGetAliasFields(t *testing.T) {
-	ClearCache()
+	ClearFieldMappingCache()
 
 	t.Setenv("ALIAS_FIELDS", "trace_id=trace.trace_id,span_id=trace.span_id")
 

--- a/s3-handler/albevent/albevent.go
+++ b/s3-handler/albevent/albevent.go
@@ -1,0 +1,188 @@
+package albevent
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/honeycombio/agentless-integrations-for-aws/common"
+	"github.com/honeycombio/honeytail/httime"
+	"github.com/honeycombio/libhoney-go"
+)
+
+type Event struct {
+	mappings map[string]interface{}
+	event    *libhoney.Event
+
+	Timestamp time.Time
+}
+
+func (e *Event) Fields() map[string]interface{} {
+	return e.event.Fields()
+}
+
+func (e *Event) Field(name string) interface{} {
+	return e.event.Fields()[name]
+}
+
+func (e *Event) Event() *libhoney.Event {
+	return e.event
+}
+
+func (e *Event) AddField(name string, value interface{}) {
+	e.event.AddField(name, value)
+}
+
+func (e *Event) AddFields(values map[string]interface{}) {
+	e.event.Add(values)
+}
+
+func (e *Event) handleTimestamps() {
+	timeFieldName := os.Getenv("TIME_FIELD_NAME")
+	timeFieldFormat := os.Getenv("TIME_FIELD_FORMAT")
+
+	e.event.Timestamp = httime.GetTimestamp(e.mappings, timeFieldName, timeFieldFormat)
+	e.Timestamp = e.event.Timestamp
+
+	if seconds, err := strconv.ParseFloat(fmt.Sprintf("%s", e.mappings["target_processing_time"]), 32); err == nil {
+		e.event.AddField("duration_ms", float32(seconds*1000))
+	}
+}
+
+func (e *Event) addParsedAttributes() {
+	if os.Getenv("PARSER_TYPE") != "json" {
+		e.event.Add(common.ConvertTypes(e.mappings))
+	} else {
+		e.event.Add(e.mappings)
+	}
+}
+
+func (e *Event) addTraceId() {
+	if "w3c" != os.Getenv("TRACE_FORMAT") {
+		if e.mappings["trace_id"] == nil {
+			return
+		}
+
+		e.event.AddField("trace.trace_id", e.mappings["trace_id"])
+		e.event.AddField("trace.span_id", e.mappings["trace_id"])
+		return
+	}
+
+	if traceParts, err := getW3CTraceParts(e.mappings["trace_id"]); err == nil {
+		e.event.AddField("trace.trace_id", traceParts.traceId)
+		e.event.AddField("trace.span_id", traceParts.spanId)
+	}
+}
+
+func getW3CTraceParts(traceId interface{}) (*TraceInfo, error) {
+	amzTraceId := fmt.Sprintf("%s", traceId)
+
+	if len(amzTraceId) < 35 {
+		return nil, errors.New(fmt.Sprintf("trace id (%s) is in an invalid format", amzTraceId))
+	}
+
+	w3cTraceId := amzTraceId[2:10] + amzTraceId[11:]
+	w3cSpanId := amzTraceId[len(amzTraceId)-16:]
+
+	return &TraceInfo{traceId: w3cTraceId, spanId: w3cSpanId}, nil
+}
+
+func (e *Event) addUrlAttributes() *Event {
+	if urlInfo, err := getUrlInfo(e.mappings["request"]); err == nil {
+		e.AddFields(map[string]interface{}{
+			"name":                 fmt.Sprintf("%s %s", urlInfo.Method, urlInfo.Path),
+			"request.method":       urlInfo.Method,
+			"request.path":         urlInfo.Path,
+			"request.query_string": urlInfo.QueryString,
+		})
+	}
+
+	return e
+}
+
+func (e *Event) inspectErrorCause() *Event {
+	if error_cause, ok := e.mappings["error_cause"]; ok && error_cause != "-" {
+		e.AddField("error", error_cause)
+	}
+
+	return e
+}
+
+func (e *Event) Send() {
+	e.event.Send()
+}
+
+type TraceInfo struct {
+	traceId string
+	spanId  string
+}
+
+type UrlInfo struct {
+	Method      string
+	Path        string
+	QueryString string
+}
+
+func getUrlInfo(requestValue interface{}) (*UrlInfo, error) {
+	request := fmt.Sprintf("%s", requestValue)
+	requestParts := strings.Split(fmt.Sprintf("%s", request), " ")
+	if len(requestParts) != 3 {
+		return nil, errors.New(fmt.Sprintf("request (%s) in invalid format", request))
+	}
+
+	url, err := url.Parse(requestParts[1])
+	if err != nil {
+		return nil, err
+	}
+
+	return &UrlInfo{
+		Method:      requestParts[0],
+		Path:        url.Path,
+		QueryString: url.RawQuery,
+	}, nil
+}
+
+func filterFields(mappings map[string]interface{}) {
+	for _, field := range common.GetFilterFields() {
+		delete(mappings, field)
+	}
+}
+
+func renameFields(mappings map[string]interface{}) {
+	for k, v := range common.GetRenameFields() {
+		if tmp, ok := mappings[k]; ok {
+			mappings[v] = tmp
+			delete(mappings, k)
+		}
+	}
+}
+
+func aliasFields(mappings map[string]interface{}) {
+	for k, v := range common.GetAliasFields() {
+		if tmp, ok := mappings[k]; ok {
+			mappings[v] = tmp
+		}
+	}
+}
+
+func NewEvent(mappings map[string]interface{}) Event {
+	filterFields(mappings)
+	renameFields(mappings)
+	aliasFields(mappings)
+
+	event := libhoney.NewEvent()
+	albEvent := Event{mappings: mappings, event: event}
+	albEvent.AddFields(map[string]interface{}{"service_name": "alb", "environment": os.Getenv("ENVIRONMENT")})
+
+	albEvent.handleTimestamps()
+	albEvent.addParsedAttributes()
+	albEvent.addTraceId()
+	albEvent.addUrlAttributes()
+	albEvent.inspectErrorCause()
+
+	return albEvent
+}

--- a/s3-handler/albevent/albevent_test.go
+++ b/s3-handler/albevent/albevent_test.go
@@ -144,7 +144,7 @@ func TestItCanAddMultipleFields(t *testing.T) {
 func TestItCanFilterFields(t *testing.T) {
 	t.Setenv("FILTER_FIELDS", "no,remove_me")
 
-	common.ClearCache()
+	common.ClearFieldMappingCache()
 
 	mappings := map[string]interface{}{"yes": "keep", "no": "bad", "remove_me": false}
 	albEvent := NewEvent(mappings)
@@ -156,7 +156,7 @@ func TestItCanFilterFields(t *testing.T) {
 func TestItCanRenameFields(t *testing.T) {
 	t.Setenv("RENAME_FIELDS", "some_field=new_jack")
 
-	common.ClearCache()
+	common.ClearFieldMappingCache()
 
 	mappings := map[string]interface{}{"some_field": "whatever"}
 	albEvent := NewEvent(mappings)
@@ -168,7 +168,7 @@ func TestItCanRenameFields(t *testing.T) {
 func TestItCanAliasFields(t *testing.T) {
 	t.Setenv("ALIAS_FIELDS", "keep_me=new_jack")
 
-	common.ClearCache()
+	common.ClearFieldMappingCache()
 
 	mappings := map[string]interface{}{"keep_me": "whatever"}
 	albEvent := NewEvent(mappings)

--- a/s3-handler/albevent/albevent_test.go
+++ b/s3-handler/albevent/albevent_test.go
@@ -1,0 +1,178 @@
+package albevent
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/honeycombio/agentless-integrations-for-aws/common"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	timestampLayout string = "2006-01-02T15:04:05.9999Z"
+)
+
+func TestAlbEventTimestamp(t *testing.T) {
+	t.Setenv("TIME_FIELD_NAME", "fancy_timestamp")
+	t.Setenv("TIME_FIELD_FORMAT", timestampLayout)
+
+	mappings := map[string]interface{}{"fancy_timestamp": "2022-01-07T13:12:11.1234Z"}
+	albEvent := NewEvent(mappings)
+
+	expected, _ := time.Parse(timestampLayout, "2022-01-07T13:12:11.1234Z")
+
+	assert.Equal(t, expected, albEvent.Timestamp, "it gets its timestamp from the mappings")
+}
+
+func TestItSetsTheServiceName(t *testing.T) {
+	albEvent := NewEvent(map[string]interface{}{})
+	actual := albEvent.Field("service_name")
+
+	assert.Equal(t, "alb", actual)
+}
+
+func TestItSetsTheEnvironment(t *testing.T) {
+	t.Setenv("ENVIRONMENT", "envy")
+
+	albEvent := NewEvent(map[string]interface{}{})
+	actual := albEvent.Field("environment")
+
+	assert.Equal(t, "envy", actual)
+}
+
+func TestItPassesThroughAmznTraceIdByDefault(t *testing.T) {
+	amznTraceEpoch := "abcdef12"              // 8-hex epoch
+	amznTraceId := "abc123def456ghi789jkl012" // 24-hex unique trace id
+	xAmznTraceId := fmt.Sprintf("1-%s-%s", amznTraceEpoch, amznTraceId)
+
+	mappings := map[string]interface{}{"trace_id": xAmznTraceId}
+	albEvent := NewEvent(mappings)
+
+	assert.Equal(t, xAmznTraceId, albEvent.Field("trace.trace_id"))
+
+	assert.Equal(t, xAmznTraceId, albEvent.Field("trace.span_id"))
+}
+
+func TestItUsesW3CTraceIdsIfAsked(t *testing.T) {
+	t.Setenv("TRACE_FORMAT", "w3c")
+
+	amznTraceEpoch := "abcdef12"              // 8-hex epoch
+	amznTraceId := "abc123def456ghi789jkl012" // 24-hex unique trace id
+
+	mappings := map[string]interface{}{"trace_id": fmt.Sprintf("1-%s-%s", amznTraceEpoch, amznTraceId)}
+	albEvent := NewEvent(mappings)
+
+	assert.Equal(t, amznTraceEpoch+amznTraceId, albEvent.Field("trace.trace_id"))
+
+	expectedSpanId := amznTraceId[len(amznTraceId)-16:]
+	assert.Equal(t, expectedSpanId, albEvent.Field("trace.span_id"))
+}
+
+func TestItDerivesItsDurationFromTargetProcessingTime(t *testing.T) {
+	mappings := map[string]interface{}{"target_processing_time": "0.1234"}
+	albEvent := NewEvent(mappings)
+	fields := albEvent.Fields()
+
+	var expected float32 = 123.4
+	assert.Equal(t, expected, fields["duration_ms"])
+}
+
+func TestItAddsRequestInfo(t *testing.T) {
+	request := "GET https://whatever.com:443/path/to/thing.html?moar=stuff HTTP/2.0"
+	mappings := map[string]interface{}{"request": request}
+	albEvent := NewEvent(mappings)
+
+	fields := albEvent.Fields()
+
+	assert.Equal(t, "GET /path/to/thing.html", fields["name"])
+	assert.Equal(t, "GET", fields["request.method"])
+	assert.Equal(t, "/path/to/thing.html", fields["request.path"])
+	assert.Equal(t, "moar=stuff", fields["request.query_string"])
+}
+
+func TestItAddsTheParsedValuesToTheTrace(t *testing.T) {
+	mappings := map[string]interface{}{"what": "ever", "things": 123}
+	albEvent := NewEvent(mappings)
+
+	fields := albEvent.Fields()
+
+	assert.Equal(t, "ever", fields["what"])
+	assert.Equal(t, 123, fields["things"])
+}
+
+func TestItHandlesAlbErrorCauses(t *testing.T) {
+	tests := []struct {
+		error_cause    string
+		expected_error interface{}
+	}{
+		{error_cause: "-", expected_error: nil},
+		{error_cause: "Bad Stuff", expected_error: "Bad Stuff"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.error_cause, func(t *testing.T) {
+			mappings := map[string]interface{}{"error_cause": tt.error_cause}
+			albEvent := NewEvent(mappings)
+
+			assert.Equal(t, tt.expected_error, albEvent.Field("error"))
+		})
+	}
+}
+
+func TestItCanAddFields(t *testing.T) {
+	mappings := map[string]interface{}{}
+	albEvent := NewEvent(mappings)
+
+	albEvent.AddField("some", "value")
+	albEvent.AddField("other_stuff", float32(1.23))
+
+	assert.Equal(t, "value", albEvent.Field("some"))
+	assert.Equal(t, float32(1.23), albEvent.Field("other_stuff"))
+}
+
+func TestItCanAddMultipleFields(t *testing.T) {
+	mappings := map[string]interface{}{}
+	albEvent := NewEvent(mappings)
+
+	albEvent.AddFields(map[string]interface{}{"flerpn": "derpn", "hi": 123})
+
+	assert.Equal(t, "derpn", albEvent.Field("flerpn"))
+	assert.Equal(t, 123, albEvent.Field("hi"))
+}
+
+func TestItCanFilterFields(t *testing.T) {
+	t.Setenv("FILTER_FIELDS", "no,remove_me")
+
+	common.ClearCache()
+
+	mappings := map[string]interface{}{"yes": "keep", "no": "bad", "remove_me": false}
+	albEvent := NewEvent(mappings)
+
+	expected := map[string]interface{}{"yes": "keep", "service_name": "alb", "environment": ""}
+	assert.Equal(t, expected, albEvent.Fields())
+}
+
+func TestItCanRenameFields(t *testing.T) {
+	t.Setenv("RENAME_FIELDS", "some_field=new_jack")
+
+	common.ClearCache()
+
+	mappings := map[string]interface{}{"some_field": "whatever"}
+	albEvent := NewEvent(mappings)
+
+	assert.Equal(t, "whatever", albEvent.Field("new_jack"))
+	assert.Equal(t, nil, albEvent.Field("some_field"))
+}
+
+func TestItCanAliasFields(t *testing.T) {
+	t.Setenv("ALIAS_FIELDS", "keep_me=new_jack")
+
+	common.ClearCache()
+
+	mappings := map[string]interface{}{"keep_me": "whatever"}
+	albEvent := NewEvent(mappings)
+
+	assert.Equal(t, "whatever", albEvent.Field("new_jack"))
+	assert.Equal(t, "whatever", albEvent.Field("keep_me"))
+}

--- a/s3-handler/main_test.go
+++ b/s3-handler/main_test.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	exitVal := m.Run()
+
+	os.Exit(exitVal)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Out of the box, we had troubles getting our trace propagation to work. Part of the problem was the absence of a `span_id` being set. Because of this we could not get our traces to marry up between our ALB and our rails application.

## Short description of the changes

- adds ALIAS_FIELDS feature which is like RENAME_FIELDS but leaves the original attribute intact
- refactored the s3-handler/main.go code to abstract an albevent to make it easier to test what fields are set
- added some additional request information from the url parts like
  - request.path
  - request.query_string
  - request.method
- added a name property to give an alb span a default one
- set the service_name to alb
- addes a `TRACE_FORMAT` feature which allows for `"w3c`" to generate a W3C formatted trace id from an `X-Amzn-Trace-Id`
  * uses the `<8HEX epoch><24HEX globally unique id>` to generated the `<32HEX unique trace id>` that https://www.w3.org/TR/trace-context/#version-format speaks about as the `trace.trace_id`
  * uses the least-significant `<16HEX>` bits from the `<24HEX globally unique id>` as the `trace.span_id`

## Notes
Please note that these are the first lines of `go` I've ever typed, so please let me know if I'm doing something that isn't idiomatic of `golang` or any other problems otherwise. Thanks!

