### PR TITLE
[fix] Remove trailing "t" from default RDS log_line_prefix

### DIFF
--- a/templates/cloudwatch-rds-postgresql.yml
+++ b/templates/cloudwatch-rds-postgresql.yml
@@ -26,7 +26,7 @@ Parameters:
     Description: Sample rate. See https://honeycomb.io/docs/guides/sampling/.
   LogLinePrefix:
     Type: String
-    Default: '%t:%r:%u@%d:[%p]:t'
+    Default: '%t:%r:%u@%d:[%p]:'
     Description: The prefix of each log line. See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.Concepts.PostgreSQL.html#USER_LogAccess.Concepts.PostgreSQL.Log_Format
   LogGroupName:
     Type: String


### PR DESCRIPTION
## Which problem is this PR solving?

- Despite [the AWS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.Concepts.PostgreSQL.html#USER_LogAccess.Concepts.PostgreSQL.Log_Format) at the time of this commit stating that there is a literal `t` at the end of the default-and-unchangeable `log_line_prefix`, there is no literal `t` at the end of the log_line_prefix in the actual RDS config. The literal-`t`'s presence in our template prevents log lines being matched (crf. [thread about this in Pollinators Slack](https://honeycombpollinators.slack.com/archives/C4T3A32CX/p1663727789316189?thread_ts=1658919158.833459&cid=C4T3A32CX)) by the Honeycomb RDS CloudWatch log processor because there is no literal-`t` that follows the colon that follows the process id in the actual log line output.

## Short description of the changes

- Removes the `t` from our template's `log_line_prefix`.

