### PR TITLE
[s3] Protect against Intn panicing if sample rate is set to 0

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -38,7 +38,9 @@ func InitHoneycombFromEnvVars() error {
 	sampleRate = 1
 	if os.Getenv("SAMPLE_RATE") != "" {
 		i, err := strconv.Atoi(os.Getenv("SAMPLE_RATE"))
-		if err != nil {
+		// including a check on sample rate being configured as 0.
+		// assumption: intention of setting 0 is that no sampling is desired.
+		if err != nil || uint(i) == 0 {
 			logrus.WithField("sample_rate", os.Getenv("SAMPLE_RATE")).
 				Warn("Warning: unable to parse sample rate, falling back to 1.")
 		}

--- a/common/common.go
+++ b/common/common.go
@@ -40,7 +40,7 @@ func InitHoneycombFromEnvVars() error {
 		i, err := strconv.Atoi(os.Getenv("SAMPLE_RATE"))
 		// including a check on sample rate being configured as 0.
 		// assumption: intention of setting 0 is that no sampling is desired.
-		if err != nil || uint(i) == 0 {
+		if err != nil || i <= 0 {
 			logrus.WithField("sample_rate", os.Getenv("SAMPLE_RATE")).
 				Warn("Warning: unable to parse sample rate or sample rate configured as 0, falling back to 1.")
 		} else {

--- a/common/common.go
+++ b/common/common.go
@@ -42,7 +42,7 @@ func InitHoneycombFromEnvVars() error {
 		// assumption: intention of setting 0 is that no sampling is desired.
 		if err != nil || uint(i) == 0 {
 			logrus.WithField("sample_rate", os.Getenv("SAMPLE_RATE")).
-				Warn("Warning: unable to parse sample rate, falling back to 1.")
+				Warn("Warning: unable to parse sample rate or sample rate configured as 0, falling back to 1.")
 		}
 		sampleRate = uint(i)
 	}

--- a/common/common.go
+++ b/common/common.go
@@ -43,8 +43,9 @@ func InitHoneycombFromEnvVars() error {
 		if err != nil || uint(i) == 0 {
 			logrus.WithField("sample_rate", os.Getenv("SAMPLE_RATE")).
 				Warn("Warning: unable to parse sample rate or sample rate configured as 0, falling back to 1.")
+		} else {
+			sampleRate = uint(i)
 		}
-		sampleRate = uint(i)
 	}
 
 	// If KMS_KEY_ID is supplied, we assume we're dealing with an encrypted key.

--- a/s3-handler/main.go
+++ b/s3-handler/main.go
@@ -71,7 +71,7 @@ func Handler(request events.S3Event) (Response, error) {
 				}).Info("parser checkpoint")
 			}
 
-			if sampleRate != 0 && sampleRate != 1 && rand.Intn(int(sampleRate)) != 0 {
+			if sampleRate != 1 && rand.Intn(int(sampleRate)) != 0 {
 				// Pre-sample before even attempting to parse line.
 				continue
 			}

--- a/s3-handler/main.go
+++ b/s3-handler/main.go
@@ -71,7 +71,7 @@ func Handler(request events.S3Event) (Response, error) {
 				}).Info("parser checkpoint")
 			}
 
-			if sampleRate != 1 && rand.Intn(int(sampleRate)) != 0 {
+			if sampleRate != 0 && sampleRate != 1 && rand.Intn(int(sampleRate)) != 0 {
 				// Pre-sample before even attempting to parse line.
 				continue
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

double checks sample rate is not set to 0 as well 
* the function we use to get back a non-negative pseudo-random number in the half-open interval [0, sample rate) panics if sample rate <= 0.


