### PR TITLE
Embed service regexs into code

### DIFF
--- a/sam-templates/vpc-flow-logs.yml
+++ b/sam-templates/vpc-flow-logs.yml
@@ -1,26 +1,26 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: Sends VPC flow logs to Honeycomb
-Parameters: 
-  Environment: 
+Parameters:
+  Environment:
     Type: String
     Default: ''
     Description: Name of environment, if applicable - will get appended to each event
-  HoneycombWriteKey: 
+  HoneycombWriteKey:
     Type: String
     Description: KMS-encrypted blob of your honeycomb write key.
   KMSKeyId:
     Type: String
     Description: Id of KMS key used to encrypt the Honeycomb Write Key
-  HoneycombAPIHost: 
+  HoneycombAPIHost:
     Type: String
     Default: https://api.honeycomb.io
     Description: Optionally set an alternative API host
-  HoneycombDataset: 
+  HoneycombDataset:
     Type: String
     Default: vpc-flow-logs
     Description: Target honeycomb dataset
-  HoneycombSampleRate: 
+  HoneycombSampleRate:
     Type: Number
     Default: 1
     Description: Sample rate - for higher volumes, we recommend increasing this.
@@ -39,8 +39,7 @@ Resources:
       Environment:
         Variables:
           ENVIRONMENT: !Ref Environment
-          PARSER_TYPE: regex
-          REGEX_PATTERN: '(?P<version>\d+) (?P<account_id>\d+) (?P<interface_id>eni-[0-9a-f]+) (?P<src_addr>[\d\.]+) (?P<dst_addr>[\d\.]+) (?P<src_port>\d+) (?P<dst_port>\d+) (?P<protocol>\d+) (?P<packets>\d+) (?P<bytes>\d+) (?P<start_time>\d+) (?P<end_time>\d+) (?P<action>[A-Z]+) (?P<log_status>[A-Z]+)'
+          PARSER_TYPE: vpc-flow
           HONEYCOMB_WRITE_KEY: !Ref HoneycombWriteKey
           API_HOST: !Ref HoneycombAPIHost
           DATASET: !Ref HoneycombDataset

--- a/templates/aws-alb-logs.yml
+++ b/templates/aws-alb-logs.yml
@@ -86,8 +86,7 @@ Resources:
       Environment:
         Variables:
           ENVIRONMENT: !Ref Environment
-          PARSER_TYPE: regex
-          REGEX_PATTERN: '(?P<type>[^ ]+) (?P<timestamp>[^ ]+) (?P<elb>[^ ]+) (?P<client>[^ ]+) (?P<target>[^ ]+) (?P<request_processing_time>[^ ]+) (?P<target_processing_time>[^ ]+) (?P<response_processing_time>[^ ]+) (?P<elb_status_code>[^ ]+) (?P<target_status_code>[^ ]+) (?P<received_bytes>[^ ]+) (?P<sent_bytes>[^ ]+) "(?P<request>[^"]+)" "(?P<user_agent>[^"]+)" (?P<ssl_cipher>[^ ]+) (?P<ssl_protocol>[^ ]+) (?P<target_group_arn>[^ ]+) "Root=(?P<trace_id>[^"]+)" "(?P<domain_name>[^"]+)" "(?P<chosen_cert_arn>[^"]+)" (?P<matched_rule_priority>[^ ]+) (?P<request_creation_time>[^ ]+) "(?P<actions_executed>[^"]+)" "(?P<redirect_url>[^"]+)" "(?P<error_reason>[^"]+)" "(?P<target_list>[^"]+)" "(?P<target_status_code_list>[^"]+)"'
+          PARSER_TYPE: alb
           HONEYCOMB_WRITE_KEY: !Ref HoneycombWriteKey
           KMS_KEY_ID: !Ref KMSKeyId
           API_HOST: !Ref HoneycombAPIHost

--- a/templates/aws-elb-logs.yml
+++ b/templates/aws-elb-logs.yml
@@ -81,8 +81,7 @@ Resources:
       Environment:
         Variables:
           ENVIRONMENT: !Ref Environment
-          PARSER_TYPE: regex
-          REGEX_PATTERN: '(?P<timestamp>.+) (?P<elb>.+) (?P<client_authority>.+) (?P<backend_authority>.+) (?P<request_processing_time>.+) (?P<backend_processing_time>.+) (?P<response_processing_time>.+) (?P<elb_status_code>.+) (?P<backend_status_code>.+) (?P<received_bytes>.+) (?P<sent_bytes>.+) (?P<request>".+") (?P<user_agent>".+") (?P<ssl_cipher>.+) (?P<ssl_protocol>.+)'
+          PARSER_TYPE: elb
           HONEYCOMB_WRITE_KEY: !Ref HoneycombWriteKey
           KMS_KEY_ID: !Ref KMSKeyId
           API_HOST: !Ref HoneycombAPIHost

--- a/templates/s3-bucket-logs.yml
+++ b/templates/s3-bucket-logs.yml
@@ -71,8 +71,7 @@ Resources:
       Environment:
         Variables:
           ENVIRONMENT: !Ref Environment
-          PARSER_TYPE: regex
-          REGEX_PATTERN: '(?P<bucket_owner>[^\s]+) (?P<bucket>[^\s]+) \[(?P<timestamp>.+?)\] (?P<remote_ip>[^\s]+) (?P<requester>[^\s]+) (?P<request_id>[^\s]+) (?P<operation>[^\s]+) (?P<key>[^\s]+) "(?P<request_uri>.+?)" (?P<http_status>[^\s]+) (?P<error_code>[^\s]+) (?P<bytes_sent>[^\s]+) (?P<object_size>[^\s]+) (?P<total_time>[^\s]+) (?P<turnaround_time>[^\s]+) "(?P<referrer>.+?)" "(?P<user_agent>.+?)" (?P<version_id>[^\s]+) (?P<host_id>[^\s]+) (?P<signature_version>[^\s]+) (?P<cipher_suite>[^\s]+) (?P<auth_type>[^\s]+) (?P<host_header>[^\s]+) (?P<tls_version>[^\s]+)'
+          PARSER_TYPE: s3-access
           HONEYCOMB_WRITE_KEY: !Ref HoneycombWriteKey
           KMS_KEY_ID: !Ref KMSKeyId
           API_HOST: !Ref HoneycombAPIHost

--- a/templates/vpc-flow-logs.yml
+++ b/templates/vpc-flow-logs.yml
@@ -71,8 +71,7 @@ Resources:
       Environment:
         Variables:
           ENVIRONMENT: !Ref Environment
-          PARSER_TYPE: regex
-          REGEX_PATTERN: '(?P<version>\d+) (?P<account_id>\d+) (?P<interface_id>eni-[0-9a-f]+) (?P<src_addr>[\d\.]+) (?P<dst_addr>[\d\.]+) (?P<src_port>\d+) (?P<dst_port>\d+) (?P<protocol>\d+) (?P<packets>\d+) (?P<bytes>\d+) (?P<start_time>\d+) (?P<end_time>\d+) (?P<action>[A-Z]+) (?P<log_status>[A-Z]+)'
+          PARSER_TYPE: vpc-flow
           HONEYCOMB_WRITE_KEY: !Ref HoneycombWriteKey
           KMS_KEY_ID: !Ref KMSKeyId
           API_HOST: !Ref HoneycombAPIHost

--- a/terraform/vpc-flow-logs.tf
+++ b/terraform/vpc-flow-logs.tf
@@ -74,9 +74,7 @@ resource "aws_lambda_function" "vpc_flow_log" {
   environment {
     variables = {
       ENVIRONMENT = "production" # change me
-      PARSER_TYPE = "regex"
-      # this pattern has been tested against the current version of VPC flow logs
-      REGEX_PATTERN = "(?P<version>\\d+) (?P<account_id>\\d+) (?P<interface_id>eni-[0-9a-f]+) (?P<src_addr>[\\d\\.]+) (?P<dst_addr>[\\d\\.]+) (?P<src_port>\\d+) (?P<dst_port>\\d+) (?P<protocol>\\d+) (?P<packets>\\d+) (?P<bytes>\\d+) (?P<start_time>\\d+) (?P<end_time>\\d+) (?P<action>[A-Z]+) (?P<log_status>[A-Z]+)"
+      PARSER_TYPE = "vpc-flow"
       # Change this to your encrypted Honeycomb write key or your raw write key (not recommended)
       HONEYCOMB_WRITE_KEY = "CHANGEME"
       # If the write key is encrypted, specify the KMS Key ID used to encrypt your write key


### PR DESCRIPTION
## Which problem is this PR solving?

We'd like to add more Terraform modules supporting deployment of these lambdas, so rather than copying around these big regexps to a bunch of places, embed them as consts in the code.

## Short description of the changes

Add new `PARSER_TYPE` values for `alb`, `elb`, `vpc-flow`, and `s3-access`. The `regex` parser still works as before, so this should be backwards compatible.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203221920608272