### PR TITLE
publish every main build to S3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,11 @@ filters_publish: &filters_publish
     branches:
       ignore: /.*/
 
+filters_main: &filters_main
+  filters:
+    branches:
+      only: main
+
 orbs:
   aws-cli: circleci/aws-cli@2.0.3
 
@@ -102,7 +107,7 @@ workflows:
           requires:
             - go_test
       - publish_aws:
-          <<: *filters_publish
+          <<: *filters_main
           context: Honeycomb Secrets for Public Repos
           requires:
             - validate_templates

--- a/publish_aws.sh
+++ b/publish_aws.sh
@@ -27,8 +27,8 @@ fi
 echo "+++ Uploading handlers"
 for REGION in ${REGIONS}; do
 	DEPLOY_ROOT=s3://honeycomb-integrations-${REGION}/agentless-integrations-for-aws
-	aws s3 cp ${DRYRUN} ${ZIP_PATH} ${DEPLOY_ROOT}/LATEST/${ZIP_NAME}
 	aws s3 cp ${DRYRUN} ${ZIP_PATH} ${DEPLOY_ROOT}/${VERSION}/${ZIP_NAME}
+	[[ -n "$CIRCLE_TAG" ]] && aws s3 cp ${DRYRUN} ${ZIP_PATH} ${DEPLOY_ROOT}/LATEST/${ZIP_NAME}
 done
 
 # publish the templates to our builds bucket
@@ -36,6 +36,6 @@ DEPLOY_ROOT=s3://honeycomb-builds/honeycombio/integrations-for-aws
 
 echo "+++ Uploading templates"
 for TEMPLATE in templates/*; do
-	aws s3 cp ${DRYRUN} ${TEMPLATE} ${DEPLOY_ROOT}/LATEST/${TEMPLATE}
 	aws s3 cp ${DRYRUN} ${TEMPLATE} ${DEPLOY_ROOT}/${VERSION}/${TEMPLATE}
+	[[ -n "$CIRCLE_TAG" ]] && aws s3 cp ${DRYRUN} ${TEMPLATE} ${DEPLOY_ROOT}/LATEST/${TEMPLATE}
 done


### PR DESCRIPTION
## Which problem is this PR solving?

I'd like to be able to test main-line builds of this repo. Right now, afaict this requires pulling down the code and manually building/publishing the resulting zip to S3 somewhere.

## Short description of the changes

Instead, change CI to push every build to S3. It appears that `publish_aws.sh` already has support for non-tagged builds in the form of [GIT_VERSION](https://github.com/honeycombio/agentless-integrations-for-aws/blob/main/publish_aws.sh#L10-L11), so all that needs to be done is to run that script on any commit to main.
