### PR TITLE
Add API team as co-codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/telemetry-team
+* @honeycombio/telemetry-team @honeycombio/api-team


### PR DESCRIPTION
## Which problem is this PR solving?
Adds @honeycombio/api-team as co-codeowners.

## Short description of the changes
- Add @honeycombio/api-team to CODEOWNERS file

