### PR TITLE
don't fail CI just because we're not on a tag

### DIFF
--- a/publish_aws.sh
+++ b/publish_aws.sh
@@ -28,7 +28,7 @@ echo "+++ Uploading handlers"
 for REGION in ${REGIONS}; do
 	DEPLOY_ROOT=s3://honeycomb-integrations-${REGION}/agentless-integrations-for-aws
 	aws s3 cp ${DRYRUN} ${ZIP_PATH} ${DEPLOY_ROOT}/${VERSION}/${ZIP_NAME}
-	[[ -n "$CIRCLE_TAG" ]] && aws s3 cp ${DRYRUN} ${ZIP_PATH} ${DEPLOY_ROOT}/LATEST/${ZIP_NAME}
+	[[ -n "$CIRCLE_TAG" ]] && aws s3 cp ${DRYRUN} ${ZIP_PATH} ${DEPLOY_ROOT}/LATEST/${ZIP_NAME} || true
 done
 
 # publish the templates to our builds bucket
@@ -37,5 +37,5 @@ DEPLOY_ROOT=s3://honeycomb-builds/honeycombio/integrations-for-aws
 echo "+++ Uploading templates"
 for TEMPLATE in templates/*; do
 	aws s3 cp ${DRYRUN} ${TEMPLATE} ${DEPLOY_ROOT}/${VERSION}/${TEMPLATE}
-	[[ -n "$CIRCLE_TAG" ]] && aws s3 cp ${DRYRUN} ${TEMPLATE} ${DEPLOY_ROOT}/LATEST/${TEMPLATE}
+	[[ -n "$CIRCLE_TAG" ]] && aws s3 cp ${DRYRUN} ${TEMPLATE} ${DEPLOY_ROOT}/LATEST/${TEMPLATE} || true
 done


### PR DESCRIPTION
I believe CI is failing because L40 of publish_aws.sh is returning failure when `$CIRCLE_TAG` is unset. This should fix it.