### PR TITLE
fix: pass non-CloudWatch Log data through the Kinesis RDS transform unaltered

### DIFF
--- a/rds-mysql-kfh-transform/main.go
+++ b/rds-mysql-kfh-transform/main.go
@@ -27,7 +27,13 @@ func handler(ctx context.Context, input events.KinesisFirehoseEvent) (events.Kin
 	for _, record := range input.Records {
 		cwb, err := decodeData(record.Data)
 		if err != nil {
-			return events.KinesisFirehoseResponse{}, err
+			// not CloudWatch Logs data? Just put it back on the stream untouched
+			var unknownRecord events.KinesisFirehoseResponseRecord
+			unknownRecord.RecordID = record.RecordID
+			unknownRecord.Result = events.KinesisFirehoseTransformedStateOk
+			unknownRecord.Data = record.Data
+			response.Records = append(response.Records, unknownRecord)
+			continue
 		}
 
 		// these messages ensure kinesis can reach the lambda and don't require processing
@@ -75,7 +81,7 @@ func handler(ctx context.Context, input events.KinesisFirehoseEvent) (events.Kin
 			transformedRecord.Result = events.KinesisFirehoseTransformedStateOk
 			transformedRecord.Data = b
 			response.Records = append(response.Records, transformedRecord)
-		} 
+		}
 	}
 	return response, nil
 }

--- a/rds-postgresql-kfh-transform/main.go
+++ b/rds-postgresql-kfh-transform/main.go
@@ -27,7 +27,13 @@ func handler(ctx context.Context, input events.KinesisFirehoseEvent) (events.Kin
 	for _, record := range input.Records {
 		cwb, err := decodeData(record.Data)
 		if err != nil {
-			return events.KinesisFirehoseResponse{}, err
+			// not CloudWatch Logs data? Just put it back on the stream untouched
+			var unknownRecord events.KinesisFirehoseResponseRecord
+			unknownRecord.RecordID = record.RecordID
+			unknownRecord.Result = events.KinesisFirehoseTransformedStateOk
+			unknownRecord.Data = record.Data
+			response.Records = append(response.Records, unknownRecord)
+			continue
 		}
 
 		// these messages ensure kinesis can reach the lambda and don't require processing


### PR DESCRIPTION
This allows non-CloudWatch Log data to successfully pass through the RDS transform unaltered. The immediate use case here is to enable the Kinesis UI's `Start sending demo data` button to work as a way of validating the stream configuration.

Here's a screenshot of a single dataset with mixed parsed and Kinesis 'demo data' being processed in batches as they move through the stream:
![Screen Shot 2022-12-01 at 15 50 55](https://user-images.githubusercontent.com/511697/205158043-88751a7a-8cc7-4719-a1d5-0001af40cf70.png)

