### PR TITLE
chore: switch to temp credentials for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ filters_main_and_tags: &filters_main_and_tags
       only: /^v[0-9].*/
 
 orbs:
-  aws-cli: circleci/aws-cli@2.0.3
+  aws-cli: circleci/aws-cli@3.2.0
 
 executors:
   go:
@@ -62,8 +62,8 @@ jobs:
       - attach_workspace:
           at: ./
       - aws-cli/setup:
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          role-arn: "arn:aws:iam::702835727665:role/circleci-public-repos"
+          role-session-name: "agentless-integrations-for-aws"
           aws-region: AWS_REGION
       - run: ./publish_aws.sh
   publish_github:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Use temp creds for CI

## Short description of the changes

- Swap out using the access key for using the OIDC integration.

