### PR TITLE
chore: upgrade go1.x to provided.al2 runtime and use arm64 arch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
           at: ./
       - run:
           name: "Draft GitHub Release"
-          command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./pkg/ingest-handlers.zip
+          command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./pkg/
 
 
 # Orchestrate or schedule a set of jobs, see https://circleci.com/docs/2.0/workflows/

--- a/build.sh
+++ b/build.sh
@@ -18,8 +18,8 @@ HANDLERS="cloudwatch-handler s3-handler sns-handler mysql-handler postgresql-han
 
 for HANDLER in ${HANDLERS}; do
 	cd ${HANDLER}
-	GOARCH=amd64 GOOS=linux go build -ldflags "-X github.com/honeycombio/agentless-integrations-for-aws/common.version=${VERSION}" -o bootstrap
+	GOARCH=arm64 GOOS=linux go build -ldflags "-X github.com/honeycombio/agentless-integrations-for-aws/common.version=${VERSION}" -o bootstrap
 	zip ${HANDLER}.zip bootstrap
-	mv ${HANDLER}.zip ${ROOT_DIR}/pkg
 	cd ${ROOT_DIR}
+	mv ${HANDLER}/${HANDLER}.zip pkg
 done;

--- a/build.sh
+++ b/build.sh
@@ -18,11 +18,8 @@ HANDLERS="cloudwatch-handler s3-handler sns-handler mysql-handler postgresql-han
 
 for HANDLER in ${HANDLERS}; do
 	cd ${HANDLER}
-	GOOS=linux go build -ldflags "-X github.com/honeycombio/agentless-integrations-for-aws/common.version=${VERSION}"
+	GOARCH=amd64 GOOS=linux go build -ldflags "-X github.com/honeycombio/agentless-integrations-for-aws/common.version=${VERSION}" -o bootstrap
+	zip ${HANDLER}.zip bootstrap
+	mv ${HANDLER}.zip ${ROOT_DIR}/pkg
 	cd ${ROOT_DIR}
-	mv ${HANDLER}/${HANDLER} pkg
 done;
-
-cd ./pkg
-
-zip ingest-handlers.zip *

--- a/build.sh
+++ b/build.sh
@@ -18,8 +18,11 @@ HANDLERS="cloudwatch-handler s3-handler sns-handler mysql-handler postgresql-han
 
 for HANDLER in ${HANDLERS}; do
 	cd ${HANDLER}
+	GOARCH=amd64 GOOS=linux go build -ldflags "-X github.com/honeycombio/agentless-integrations-for-aws/common.version=${VERSION}" -o bootstrap
+	zip ${HANDLER}-amd64.zip bootstrap
 	GOARCH=arm64 GOOS=linux go build -ldflags "-X github.com/honeycombio/agentless-integrations-for-aws/common.version=${VERSION}" -o bootstrap
-	zip ${HANDLER}.zip bootstrap
+  zip ${HANDLER}-arm64.zip bootstrap
 	cd ${ROOT_DIR}
-	mv ${HANDLER}/${HANDLER}.zip pkg
+	mv ${HANDLER}/${HANDLER}-amd64.zip pkg
+	mv ${HANDLER}/${HANDLER}-arm64.zip pkg
 done;

--- a/publish_aws.sh
+++ b/publish_aws.sh
@@ -27,7 +27,7 @@ for HANDLER in ${HANDLERS}; do
   fi
 
   for REGION in ${REGIONS}; do
-    DEPLOY_ROOT=s3://brooke-test-honeycomb-integrations-${REGION}/agentless-integrations-for-aws
+    DEPLOY_ROOT=s3://honeycomb-integrations-${REGION}/agentless-integrations-for-aws
     aws s3 cp ${DRYRUN} ${ZIP_PATH} ${DEPLOY_ROOT}/${VERSION}/${ZIP_NAME}
     [[ -n "$CIRCLE_TAG" ]] && aws s3 cp ${DRYRUN} ${ZIP_PATH} ${DEPLOY_ROOT}/LATEST/${ZIP_NAME} || true
   done

--- a/publish_aws.sh
+++ b/publish_aws.sh
@@ -9,23 +9,26 @@ set -e
 GIT_VERSION="`git describe | sed -e s/^v//`"
 VERSION="${CIRCLE_TAG:-$GIT_VERSION}"
 REGIONS="us-east-1 us-east-2 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1"
-
-ZIP_NAME="ingest-handlers.zip"
-ZIP_PATH="./pkg/${ZIP_NAME}"
-
-if [[ -f "${ZIP_PATH}" ]]; then
-  echo "+++ Publishing ${ZIP_PATH} to S3"
-else
-  echo 1>&2 "$ZIP_PATH does not exist. Run build.sh?"
-	exit 1
-fi
+HANDLERS="cloudwatch-handler s3-handler sns-handler mysql-handler postgresql-handler publisher rds-mysql-kfh-transform rds-postgresql-kfh-transform"
 
 # if DRYRUN is set to anything, turn it into the awscli switch
 [[ -n "${DRYRUN}" ]] && DRYRUN="--dryrun"
 
 echo "+++ Uploading handlers"
-for REGION in ${REGIONS}; do
-	DEPLOY_ROOT=s3://honeycomb-integrations-${REGION}/agentless-integrations-for-aws
-	aws s3 cp ${DRYRUN} ${ZIP_PATH} ${DEPLOY_ROOT}/${VERSION}/${ZIP_NAME}
-	[[ -n "$CIRCLE_TAG" ]] && aws s3 cp ${DRYRUN} ${ZIP_PATH} ${DEPLOY_ROOT}/LATEST/${ZIP_NAME} || true
+for HANDLER in ${HANDLERS}; do
+  ZIP_NAME="${HANDLER}.zip"
+  ZIP_PATH="./pkg/${ZIP_NAME}"
+
+  if [[ -f "${ZIP_PATH}" ]]; then
+    echo "+++ Publishing ${ZIP_PATH} to S3"
+  else
+    echo 1>&2 "$ZIP_PATH does not exist. Run build.sh?"
+  	exit 1
+  fi
+
+  for REGION in ${REGIONS}; do
+    DEPLOY_ROOT=s3://brooke-test-honeycomb-integrations-${REGION}/agentless-integrations-for-aws
+    aws s3 cp ${DRYRUN} ${ZIP_PATH} ${DEPLOY_ROOT}/${VERSION}/${ZIP_NAME}
+    [[ -n "$CIRCLE_TAG" ]] && aws s3 cp ${DRYRUN} ${ZIP_PATH} ${DEPLOY_ROOT}/LATEST/${ZIP_NAME} || true
+  done
 done


### PR DESCRIPTION
## Which problem is this PR solving?

#218 

## Short description of the changes

Necessary changes to the build pipeline to support upgrading to the `provided.al2` runtime, using [this AWS blog](https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/) as guidance. AWS is deprecating `go1.x` on December 31st. This approach continues versioning and releasing these binaries as a unit but uploads each individual zip file to S3 and the GitHub release rather than one big `ingest-handlers.zip`.

Also snuck in a change from amd64 to arm64 to hopefully take advantage of the cost + performance savings Amazon mentions as a motivator for this change.

I tested the build script in isolation, the publish aws script in isolation, and tested a binary e2e to validate events still get to Honeycomb with the new runtime.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205446566084103