### PR TITLE
fix: update publish-aws script for both archs

### DIFF
--- a/publish_aws.sh
+++ b/publish_aws.sh
@@ -8,27 +8,28 @@ set -e
 # gd591456 - this commit's id
 GIT_VERSION="`git describe | sed -e s/^v//`"
 VERSION="${CIRCLE_TAG:-$GIT_VERSION}"
-REGIONS="us-east-1 us-east-2 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1"
+REGIONS="us-east-1"
 HANDLERS="cloudwatch-handler s3-handler sns-handler mysql-handler postgresql-handler publisher rds-mysql-kfh-transform rds-postgresql-kfh-transform"
 
 # if DRYRUN is set to anything, turn it into the awscli switch
 [[ -n "${DRYRUN}" ]] && DRYRUN="--dryrun"
 
+ZIP_PATH="./pkg"
+
+if [[ -d "${ZIP_PATH}" ]]; then
+  echo "+++ Publishing ${ZIP_PATH} to S3"
+else
+  echo 1>&2 "$ZIP_PATH does not exist. Run build.sh?"
+  exit 1
+fi
+
 echo "+++ Uploading handlers"
 for HANDLER in ${HANDLERS}; do
-  ZIP_NAME="${HANDLER}.zip"
-  ZIP_PATH="./pkg/${ZIP_NAME}"
-
-  if [[ -f "${ZIP_PATH}" ]]; then
-    echo "+++ Publishing ${ZIP_PATH} to S3"
-  else
-    echo 1>&2 "$ZIP_PATH does not exist. Run build.sh?"
-  	exit 1
-  fi
-
   for REGION in ${REGIONS}; do
-    DEPLOY_ROOT=s3://honeycomb-integrations-${REGION}/agentless-integrations-for-aws
-    aws s3 cp ${DRYRUN} ${ZIP_PATH} ${DEPLOY_ROOT}/${VERSION}/${ZIP_NAME}
-    [[ -n "$CIRCLE_TAG" ]] && aws s3 cp ${DRYRUN} ${ZIP_PATH} ${DEPLOY_ROOT}/LATEST/${ZIP_NAME} || true
+    DEPLOY_ROOT=s3://brooke-test-honeycomb-integrations-${REGION}/agentless-integrations-for-aws
+    aws s3 cp ${DRYRUN} ${ZIP_PATH}/${HANDLER}-amd64.zip ${DEPLOY_ROOT}/${VERSION}/${HANDLER}-amd64.zip
+    [[ -n "$CIRCLE_TAG" ]] && aws s3 cp ${DRYRUN} ${ZIP_PATH}/${HANDLER}-amd64.zip ${DEPLOY_ROOT}/LATEST/${HANDLER}-amd64.zip || true
+    aws s3 cp ${DRYRUN} ${ZIP_PATH}/${HANDLER}-arm64.zip ${DEPLOY_ROOT}/${VERSION}/${HANDLER}-arm64.zip
+    [[ -n "$CIRCLE_TAG" ]] && aws s3 cp ${DRYRUN} ${ZIP_PATH}/${HANDLER}-arm64.zip ${DEPLOY_ROOT}/LATEST/${HANDLER}-arm64.zip || true
   done
 done


### PR DESCRIPTION
## Which problem is this PR solving?

Follow up to #220 to make the publish-aws script work for both architectures.

## Short description of the changes

Adjusts the script to copy both amd64 and arm64 zips for each handler to S3.

