### PR TITLE
feat: Create sns-kfh-transform[er]

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ ROOT_DIR=$(pwd)
 rm -rf pkg
 mkdir pkg
 
-HANDLERS="cloudwatch-handler s3-handler sns-handler mysql-handler postgresql-handler publisher rds-mysql-kfh-transform rds-postgresql-kfh-transform"
+HANDLERS="cloudwatch-handler s3-handler sns-handler mysql-handler postgresql-handler publisher rds-mysql-kfh-transform rds-postgresql-kfh-transform sns-kfh-transform"
 
 for HANDLER in ${HANDLERS}; do
 	cd ${HANDLER}

--- a/publish_aws.sh
+++ b/publish_aws.sh
@@ -9,7 +9,7 @@ set -e
 GIT_VERSION="`git describe | sed -e s/^v//`"
 VERSION="${CIRCLE_TAG:-$GIT_VERSION}"
 REGIONS="us-east-1 us-east-2 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1"
-HANDLERS="cloudwatch-handler s3-handler sns-handler mysql-handler postgresql-handler publisher rds-mysql-kfh-transform rds-postgresql-kfh-transform"
+HANDLERS="cloudwatch-handler s3-handler sns-handler mysql-handler postgresql-handler publisher rds-mysql-kfh-transform rds-postgresql-kfh-transform sns-kfh-transform"
 
 # if DRYRUN is set to anything, turn it into the awscli switch
 [[ -n "${DRYRUN}" ]] && DRYRUN="--dryrun"

--- a/sns-kfh-transform/main.go
+++ b/sns-kfh-transform/main.go
@@ -16,6 +16,15 @@ type snsEntityForHny struct {
 	Message map[string]interface{}
 }
 
+func failedRecord(in events.KinesisFirehoseEventRecord) events.KinesisFirehoseResponseRecord {
+	var failedRecord events.KinesisFirehoseResponseRecord
+	failedRecord.RecordID = in.RecordID
+	failedRecord.Result = events.KinesisFirehoseTransformedStateProcessingFailed
+	failedRecord.Data = in.Data
+
+	return failedRecord
+}
+
 func handler(ctx context.Context, input events.KinesisFirehoseEvent) (events.KinesisFirehoseResponse, error) {
 	var response events.KinesisFirehoseResponse
 	for _, record := range input.Records {
@@ -23,18 +32,25 @@ func handler(ctx context.Context, input events.KinesisFirehoseEvent) (events.Kin
 		err := json.Unmarshal(record.Data, &snsEntity)
 		if err != nil {
 			logrus.WithError(err).Warn("failed unmarshal outer event")
+
+			response.Records = append(response.Records, failedRecord(record))
+			continue // keep processing other events
 		}
 
 		var hnyEvent = snsEntityForHny{snsEntity, map[string]interface{}{}}
 		err = json.Unmarshal([]byte(snsEntity.Message), &hnyEvent.Message)
 		if err != nil {
 			logrus.WithError(err).Warn("failed unmarshal snsEntity.Message")
+			// this is not a failed event; the outer record might still be useful
 			hnyEvent.Message["rawMessage"] = snsEntity.Message
 		}
 
 		b, err := json.Marshal(hnyEvent)
 		if err != nil {
 			logrus.WithError(err).Warn("couldn't marshal json")
+
+			response.Records = append(response.Records, failedRecord(record))
+			continue // keep processing other events
 		}
 
 		var transformedRecord events.KinesisFirehoseResponseRecord

--- a/sns-kfh-transform/main.go
+++ b/sns-kfh-transform/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/honeycombio/agentless-integrations-for-aws/common"
+	"github.com/sirupsen/logrus"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+type snsEntityForHny struct {
+	events.SNSEntity
+	Message map[string]interface{}
+}
+
+func handler(ctx context.Context, input events.KinesisFirehoseEvent) (events.KinesisFirehoseResponse, error) {
+	var response events.KinesisFirehoseResponse
+	for _, record := range input.Records {
+		var snsEntity events.SNSEntity
+		err := json.Unmarshal(record.Data, &snsEntity)
+		if err != nil {
+			logrus.WithError(err).Warn("failed unmarshal outer event")
+		}
+
+		var hnyEvent = snsEntityForHny{snsEntity, map[string]interface{}{}}
+		err = json.Unmarshal([]byte(snsEntity.Message), &hnyEvent.Message)
+		if err != nil {
+			logrus.WithError(err).Warn("failed unmarshal snsEntity.Message")
+			hnyEvent.Message["rawMessage"] = snsEntity.Message
+		}
+
+		b, err := json.Marshal(hnyEvent)
+		if err != nil {
+			logrus.WithError(err).Warn("couldn't marshal json")
+		}
+
+		var transformedRecord events.KinesisFirehoseResponseRecord
+		transformedRecord.RecordID = record.RecordID
+		transformedRecord.Result = events.KinesisFirehoseTransformedStateOk
+		transformedRecord.Data = b
+		response.Records = append(response.Records, transformedRecord)
+	}
+
+	return response, nil
+}
+
+func main() {
+	common.AddUserAgentMetadata("sns-kfh-handler", "json")
+	lambda.Start(handler)
+}


### PR DESCRIPTION
## Which problem is this PR solving?

We want to use `aws_db_event_subscription` to get `db-instance` and `db-snapshot` events into honeycomb. Since the data being sent is an [events.SNSEntity](https://github.com/aws/aws-lambda-go/blob/main/events/sns.go#L20-L32), and that struct's Message field is a json string, we need to transform it to a struct so that it can be properly unpacked by honeycomb at the receiving end.

## Short description of the changes
Part of work being done at https://app.asana.com/0/1204553808824829/1206131228284410. 

For examples of this data coming through (on a manually-deployed lambda, via https://github.com/honeycombio/infra/blob/main/terraform/modules/aws_integrations/rds_events.tf), see https://ui.kibble-eu1.honeycomb.io/honeycomb/environments/dogfood-eu1/datasets/rds-events/result/kz-S1g9i2LGo?tab=events (data generated by manually creating a db snapshot). For the trigger we intend to use this with, see https://github.com/honeycombio/infra/pull/5552 .

