### PR TITLE
fix: upgrade CI runners from Go 1.18 to 1.22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ executors:
     parameters:
       goversion:
         type: string
-        default: "18"
+        default: "22"
     working_directory: /home/circleci/go/src/github.com/honeycombio/agentless-integrations-for-aws
     docker:
       - image: cimg/go:1.<< parameters.goversion >>


### PR DESCRIPTION
## Which problem is this PR solving?

* 1.18 has been EOL'd for a while.
* Resolves build and test errors for incoming dependency updates

## Short description of the changes

* Upgrades CI runners to Go 1.22

## How to verify that this has the expected result

* CI passes!