### PR TITLE
feat: add Line Filter Rules to drop or keep based on regex

### DIFF
--- a/s3-handler/filters_test.go
+++ b/s3-handler/filters_test.go
@@ -55,6 +55,27 @@ func TestFilterKey(t *testing.T) {
 			key:            "some/random/key",
 			shouldFilter:   true,
 		},
+		// filter a line pattern
+		filterTestCase{
+			matchPatterns:  []string{"status=500"},
+			filterPatterns: []string{},
+			key:            "something log status=200 something else",
+			shouldFilter:   true,
+		},
+		// match a line pattern
+		filterTestCase{
+			matchPatterns:  []string{"status=500"},
+			filterPatterns: []string{},
+			key:            "something log status=500 something else",
+			shouldFilter:   false,
+		},
+		// filter a line pattern
+		filterTestCase{
+			matchPatterns:  []string{".+"},
+			filterPatterns: []string{"status=200"},
+			key:            "something log status=200 something else",
+			shouldFilter:   true,
+		},
 	}
 
 	for _, c := range testCases {

--- a/s3-handler/main.go
+++ b/s3-handler/main.go
@@ -248,9 +248,11 @@ func initLineFilterRules() error {
 	}
 	logrus.WithField("LINE_FILTER_RULES", rulesRaw).Info("Got line filter rules")
 
-	var err error
-	lineFilterRules, err = parseLineFilterRules([]byte(rulesRaw))
-	if len(lineFilterRules) < 1 {
+	lineFilterRules, err := parseLineFilterRules([]byte(rulesRaw))
+	if err != nil {
+		return err
+	}
+	if len(lineFilterRules) == 0 {
 		logrus.Error("Rules are empty, probably invalid JSON")
 		return nil
 	}

--- a/s3-handler/main.go
+++ b/s3-handler/main.go
@@ -266,7 +266,7 @@ func initLineFilterRules() error {
 
 	for i := range lineFilterRules {
 		// ensure there's a match pattern in a rule that has none.
-		if lineFilterRules[i].MatchLinePatterns == nil || len(lineFilterRules[i].MatchLinePatterns) < 1 {
+		if lineFilterRules[i].MatchLinePatterns == nil || len(lineFilterRules[i].MatchLinePatterns) == 0 {
 			lineFilterRules[i].MatchLinePatterns = []string{".*"}
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #259

## Short description of the changes

Customers want to be able to control which lines are sent or dropped. This implementation follows the example set by the keep/drop filters for S3 object keys. 

## How to verify that this has the expected result

Debug logs show when things are dropped.  
Also you shouldn't see events that you're trying to filter reach honeycomb. 