### PR TITLE
maint: bump ci go version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ executors:
     parameters:
       goversion:
         type: string
-        default: "22"
+        default: "24"
     working_directory: /home/circleci/go/src/github.com/honeycombio/agentless-integrations-for-aws
     docker:
       - image: cimg/go:1.<< parameters.goversion >>


### PR DESCRIPTION
Updates to go 1.24
